### PR TITLE
Feat/find root comments/yyw  -  루트 댓글들 조회 API

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
@@ -1,7 +1,7 @@
 package com.tenten.linkhub.domain.space.controller;
 
 import com.tenten.linkhub.domain.auth.MemberDetails;
-import com.tenten.linkhub.domain.space.controller.dto.MySpacesFindApiRequest;
+import com.tenten.linkhub.domain.space.controller.dto.space.MySpacesFindApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.comment.RootCommentCreateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.comment.RootCommentCreateApiResponse;
 import com.tenten.linkhub.domain.space.controller.dto.comment.RootCommentFindApiResponses;
@@ -266,6 +266,11 @@ public class SpaceController {
     /**
      * 루트 댓글 페이징 조회 API
      */
+    @Operation(
+            summary = "루트 댓글 페이징 조회 API", description = "루트 댓글 페이징 조회 API 입니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회가 성공적으로 완료 되었습니다."),
+            })
     @GetMapping(
             value = "/{spaceId}/comments",
             produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
@@ -4,6 +4,8 @@ import com.tenten.linkhub.domain.auth.MemberDetails;
 import com.tenten.linkhub.domain.space.controller.dto.MySpacesFindApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.comment.RootCommentCreateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.comment.RootCommentCreateApiResponse;
+import com.tenten.linkhub.domain.space.controller.dto.comment.RootCommentFindApiResponses;
+import com.tenten.linkhub.domain.space.controller.dto.comment.RootCommentsFindApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.MySpacesFindApiResponses;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceUpdateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceUpdateApiResponse;
@@ -14,7 +16,9 @@ import com.tenten.linkhub.domain.space.controller.dto.space.SpacesFindByQueryApi
 import com.tenten.linkhub.domain.space.controller.dto.space.SpacesFindByQueryApiResponses;
 import com.tenten.linkhub.domain.space.controller.mapper.CommentApiMapper;
 import com.tenten.linkhub.domain.space.controller.mapper.SpaceApiMapper;
+import com.tenten.linkhub.domain.space.facade.CommentFacade;
 import com.tenten.linkhub.domain.space.facade.SpaceFacade;
+import com.tenten.linkhub.domain.space.facade.dto.CommentAndChildCountAndMemberInfoResponses;
 import com.tenten.linkhub.domain.space.facade.dto.SpaceDetailGetByIdFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.dto.SpaceDetailGetByIdFacadeResponse;
 import com.tenten.linkhub.domain.space.service.CommentService;
@@ -62,13 +66,15 @@ public class SpaceController {
 
     private final SpaceFacade spaceFacade;
     private final SpaceService spaceService;
+    private final CommentFacade commentFacade;
     private final CommentService commentService;
     private final SpaceApiMapper spaceMapper;
     private final CommentApiMapper commentMapper;
 
-    public SpaceController(SpaceFacade spaceFacade, SpaceService spaceService, CommentService commentService, SpaceApiMapper spaceMapper, CommentApiMapper commentMapper) {
+    public SpaceController(SpaceFacade spaceFacade, SpaceService spaceService, CommentFacade commentFacade, CommentService commentService, SpaceApiMapper spaceMapper, CommentApiMapper commentMapper) {
         this.spaceFacade = spaceFacade;
         this.spaceService = spaceService;
+        this.commentFacade = commentFacade;
         this.commentService = commentService;
         this.spaceMapper = spaceMapper;
         this.commentMapper = commentMapper;
@@ -232,7 +238,7 @@ public class SpaceController {
     }
 
     /**
-     *  루트 댓글 생성 API
+     * 루트 댓글 생성 API
      */
     @Operation(
             summary = "루트 댓글 생성 API", description = "루트 댓글 생성 API 입니다.",
@@ -255,6 +261,24 @@ public class SpaceController {
         return ResponseEntity
                 .created(URI.create(SPACE_LOCATION_PRE_FIX + "/commments/" + savedCommentId))
                 .body(apiResponse);
+    }
+
+    /**
+     * 루트 댓글 페이징 조회 API
+     */
+    @GetMapping(
+            value = "/{spaceId}/comments",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<RootCommentFindApiResponses> findRootComments(
+            @PathVariable Long spaceId,
+            @ModelAttribute RootCommentsFindApiRequest request
+    ) {
+        PageRequest pageRequest = PageRequest.of(request.pageNumber(), request.pageSize());
+        CommentAndChildCountAndMemberInfoResponses responses = commentFacade.findRootComments(spaceId, pageRequest);
+
+        RootCommentFindApiResponses apiResponses = RootCommentFindApiResponses.from(responses);
+
+        return ResponseEntity.ok(apiResponses);
     }
 
     private void setSpaceViewCookie(HttpServletResponse servletResponse, List<Long> spaceViews) {

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
@@ -270,6 +270,8 @@ public class SpaceController {
             summary = "루트 댓글 페이징 조회 API", description = "루트 댓글 페이징 조회 API 입니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "조회가 성공적으로 완료 되었습니다."),
+                    @ApiResponse(responseCode = "404", description = "댓글을 달 수 없는 스페이스의 댓글을 보려고 합니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @GetMapping(
             value = "/{spaceId}/comments",

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentCreateApiRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentCreateApiRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Size;
 
 public record RootCommentCreateApiRequest(
         @Schema(title = "댓글 내용", example = "스페이스의 링크들이 너무 알차요!!")
-        @NotBlank(message = "댓글의 content는 null이 될 수 없습니다.")
+        @NotBlank(message = "댓글의 content는 null이나 빈 문자열이 될 수 없습니다.")
         @Size(max = 1000, message = "댓글의 content는 1000자 이상 될 수 없습니다.")
         String content
 ) {

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentFindApiResponse.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentFindApiResponse.java
@@ -1,8 +1,12 @@
 package com.tenten.linkhub.domain.space.controller.dto.comment;
 
+import java.time.LocalDateTime;
+
 public record RootCommentFindApiResponse(
         Long commentId,
         String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
         Long childCount,
         Long memberId,
         String nickname,

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentFindApiResponse.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentFindApiResponse.java
@@ -1,0 +1,12 @@
+package com.tenten.linkhub.domain.space.controller.dto.comment;
+
+public record RootCommentFindApiResponse(
+        Long commentId,
+        String content,
+        Long childCount,
+        Long memberId,
+        String nickname,
+        String aboutMe,
+        String profileImagePath
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentFindApiResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentFindApiResponses.java
@@ -1,0 +1,35 @@
+package com.tenten.linkhub.domain.space.controller.dto.comment;
+
+import com.tenten.linkhub.domain.space.facade.dto.CommentAndChildCountAndMemberInfoResponses;
+import com.tenten.linkhub.global.util.PageMetaData;
+import org.springframework.data.domain.Slice;
+
+import java.util.List;
+
+public record RootCommentFindApiResponses(
+        List<RootCommentFindApiResponse> responses,
+        PageMetaData metaData
+) {
+    public static RootCommentFindApiResponses from(CommentAndChildCountAndMemberInfoResponses responses){
+        Slice<RootCommentFindApiResponse> mapResponses = responses.responses()
+                .map(r -> new RootCommentFindApiResponse(
+                        r.commentId(),
+                        r.content(),
+                        r.childCount(),
+                        r.memberId(),
+                        r.nickname(),
+                        r.aboutMe(),
+                        r.profileImagePath()
+                ));
+
+        PageMetaData pageMetaData = new PageMetaData(
+                mapResponses.hasNext(),
+                mapResponses.getSize(),
+                mapResponses.getNumber());
+
+        return new RootCommentFindApiResponses(
+                mapResponses.getContent(),
+                pageMetaData);
+    }
+
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentFindApiResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentFindApiResponses.java
@@ -15,6 +15,8 @@ public record RootCommentFindApiResponses(
                 .map(r -> new RootCommentFindApiResponse(
                         r.commentId(),
                         r.content(),
+                        r.createdAt(),
+                        r.updatedAt(),
                         r.childCount(),
                         r.memberId(),
                         r.nickname(),

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentsFindApiRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/comment/RootCommentsFindApiRequest.java
@@ -1,0 +1,12 @@
+package com.tenten.linkhub.domain.space.controller.dto.comment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RootCommentsFindApiRequest(
+        @Schema(title = "페이지 번호", example = "0")
+        Integer pageNumber,
+
+        @Schema(title = "페이지 크기", example = "10")
+        Integer pageSize
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/space/MySpacesFindApiRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/space/MySpacesFindApiRequest.java
@@ -1,4 +1,4 @@
-package com.tenten.linkhub.domain.space.controller.dto;
+package com.tenten.linkhub.domain.space.controller.dto.space;
 
 import com.tenten.linkhub.domain.space.model.category.Category;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/CommentApiMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/CommentApiMapper.java
@@ -10,4 +10,5 @@ import org.mapstruct.Mapper;
 public interface CommentApiMapper {
 
     RootCommentCreateRequest toRootCommentCreateRequest(Long spaceId, Long memberId, String content);
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/SpaceApiMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/SpaceApiMapper.java
@@ -1,6 +1,6 @@
 package com.tenten.linkhub.domain.space.controller.mapper;
 
-import com.tenten.linkhub.domain.space.controller.dto.MySpacesFindApiRequest;
+import com.tenten.linkhub.domain.space.controller.dto.space.MySpacesFindApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceCreateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceUpdateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpacesFindByQueryApiRequest;
@@ -9,7 +9,6 @@ import com.tenten.linkhub.domain.space.facade.dto.SpaceDetailGetByIdFacadeReques
 import com.tenten.linkhub.domain.space.facade.dto.SpaceUpdateFacadeRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.MySpacesFindRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryRequest;
-import jakarta.servlet.http.Cookie;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/CommentFacade.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/CommentFacade.java
@@ -1,0 +1,41 @@
+package com.tenten.linkhub.domain.space.facade;
+
+import com.tenten.linkhub.domain.member.service.MemberService;
+import com.tenten.linkhub.domain.member.service.dto.MemberInfos;
+import com.tenten.linkhub.domain.space.facade.dto.CommentAndChildCountAndMemberInfoResponses;
+import com.tenten.linkhub.domain.space.service.CommentService;
+import com.tenten.linkhub.domain.space.service.dto.comment.CommentAndChildCountDto;
+import com.tenten.linkhub.domain.space.service.dto.comment.CommentAndChildCountResponses;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CommentFacade {
+
+    private final CommentService commentService;
+    private final MemberService memberService;
+
+    public CommentFacade(CommentService commentService, MemberService memberService) {
+        this.commentService = commentService;
+        this.memberService = memberService;
+    }
+
+    public CommentAndChildCountAndMemberInfoResponses findRootComments(Long spaceId, Pageable pageable) {
+        CommentAndChildCountResponses commentAndChildCount = commentService.findRootComments(spaceId, pageable);
+
+        List<Long> memberIds = getMemberIds(commentAndChildCount);
+
+        MemberInfos memberInfos = memberService.findMemberInfosByMemberIds(memberIds);
+
+        return CommentAndChildCountAndMemberInfoResponses.of(commentAndChildCount, memberInfos);
+    }
+
+    private List<Long> getMemberIds(CommentAndChildCountResponses rootCommentResponses) {
+        return rootCommentResponses.responses().getContent()
+                .stream()
+                .map(CommentAndChildCountDto::memberId)
+                .toList();
+    }
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/dto/CommentAndChildCountAndMemberInfo.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/dto/CommentAndChildCountAndMemberInfo.java
@@ -1,0 +1,12 @@
+package com.tenten.linkhub.domain.space.facade.dto;
+
+public record CommentAndChildCountAndMemberInfo(
+        Long commentId,
+        String content,
+        Long childCount,
+        Long memberId,
+        String nickname,
+        String aboutMe,
+        String profileImagePath
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/dto/CommentAndChildCountAndMemberInfo.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/dto/CommentAndChildCountAndMemberInfo.java
@@ -1,8 +1,12 @@
 package com.tenten.linkhub.domain.space.facade.dto;
 
+import java.time.LocalDateTime;
+
 public record CommentAndChildCountAndMemberInfo(
         Long commentId,
         String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
         Long childCount,
         Long memberId,
         String nickname,

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/dto/CommentAndChildCountAndMemberInfoResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/dto/CommentAndChildCountAndMemberInfoResponses.java
@@ -20,6 +20,8 @@ public record CommentAndChildCountAndMemberInfoResponses(Slice<CommentAndChildCo
                     return new CommentAndChildCountAndMemberInfo(
                             c.commentId(),
                             c.content(),
+                            c.createdAt(),
+                            c.updatedAt(),
                             c.childCount(),
                             c.memberId(),
                             Objects.isNull(memberInfo) ? null : memberInfo.nickname(),

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/dto/CommentAndChildCountAndMemberInfoResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/dto/CommentAndChildCountAndMemberInfoResponses.java
@@ -1,0 +1,34 @@
+package com.tenten.linkhub.domain.space.facade.dto;
+
+import com.tenten.linkhub.domain.member.service.dto.MemberInfo;
+import com.tenten.linkhub.domain.member.service.dto.MemberInfos;
+import com.tenten.linkhub.domain.space.service.dto.comment.CommentAndChildCountResponses;
+import org.springframework.data.domain.Slice;
+
+import java.util.Map;
+import java.util.Objects;
+
+public record CommentAndChildCountAndMemberInfoResponses(Slice<CommentAndChildCountAndMemberInfo> responses) {
+
+    public static CommentAndChildCountAndMemberInfoResponses of(CommentAndChildCountResponses commentAndChildCount, MemberInfos memberDetailInfos){
+        Map<Long, MemberInfo> memberInfos = memberDetailInfos.memberInfos();
+
+        Slice<CommentAndChildCountAndMemberInfo> mapResponses = commentAndChildCount.responses()
+                .map(c -> {
+                    MemberInfo memberInfo = memberInfos.get(c.memberId());
+
+                    return new CommentAndChildCountAndMemberInfo(
+                            c.commentId(),
+                            c.content(),
+                            c.childCount(),
+                            c.memberId(),
+                            Objects.isNull(memberInfo) ? null : memberInfo.nickname(),
+                            Objects.isNull(memberInfo) ? null : memberInfo.aboutMe(),
+                            Objects.isNull(memberInfo) ? null : memberInfo.path()
+                    );
+                });
+
+        return new CommentAndChildCountAndMemberInfoResponses(mapResponses);
+    }
+
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/comment/CommentRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/comment/CommentRepository.java
@@ -1,7 +1,13 @@
 package com.tenten.linkhub.domain.space.repository.comment;
 
 import com.tenten.linkhub.domain.space.model.space.Comment;
+import com.tenten.linkhub.domain.space.repository.comment.dto.CommentAndChildCommentCount;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface CommentRepository {
+
     Comment save(Comment comment);
+
+    Slice<CommentAndChildCommentCount> findCommentAndChildCommentCountBySpaceId(Long spaceId, Pageable pageable);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/comment/DefaultCommentRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/comment/DefaultCommentRepository.java
@@ -1,20 +1,31 @@
 package com.tenten.linkhub.domain.space.repository.comment;
 
 import com.tenten.linkhub.domain.space.model.space.Comment;
+import com.tenten.linkhub.domain.space.repository.comment.dto.CommentAndChildCommentCount;
+import com.tenten.linkhub.domain.space.repository.comment.query.CommentQueryRepository;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public class DefaultCommentRepository implements CommentRepository{
 
     private final CommentJpaRepository commentJpaRepository;
+    private final CommentQueryRepository commentQueryRepository;
 
-    public DefaultCommentRepository(CommentJpaRepository commentJpaRepository) {
+    public DefaultCommentRepository(CommentJpaRepository commentJpaRepository, CommentQueryRepository commentQueryRepository) {
         this.commentJpaRepository = commentJpaRepository;
+        this.commentQueryRepository = commentQueryRepository;
     }
 
     @Override
     public Comment save(Comment comment) {
         return commentJpaRepository.save(comment);
+    }
+
+    @Override
+    public Slice<CommentAndChildCommentCount> findCommentAndChildCommentCountBySpaceId(Long spaceId, Pageable pageable) {
+        return commentQueryRepository.findCommentAndChildCommentCountBySpaceId(spaceId, pageable);
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/comment/dto/CommentAndChildCommentCount.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/comment/dto/CommentAndChildCommentCount.java
@@ -1,0 +1,14 @@
+package com.tenten.linkhub.domain.space.repository.comment.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.tenten.linkhub.domain.space.model.space.Comment;
+
+public record CommentAndChildCommentCount(Comment comment, Long childCommentCount) {
+
+    @QueryProjection
+    public CommentAndChildCommentCount(Comment comment, Long childCommentCount) {
+        this.comment = comment;
+        this.childCommentCount = childCommentCount;
+    }
+
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/comment/query/CommentQueryRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/comment/query/CommentQueryRepository.java
@@ -1,0 +1,57 @@
+package com.tenten.linkhub.domain.space.repository.comment.query;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tenten.linkhub.domain.space.model.space.Comment;
+import com.tenten.linkhub.domain.space.model.space.QComment;
+import com.tenten.linkhub.domain.space.repository.comment.dto.CommentAndChildCommentCount;
+import com.tenten.linkhub.domain.space.repository.comment.dto.QCommentAndChildCommentCount;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.tenten.linkhub.domain.space.model.space.QComment.comment;
+
+@Repository
+public class CommentQueryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public CommentQueryRepository(JPAQueryFactory queryFactory) {
+        this.queryFactory = queryFactory;
+    }
+
+    public Slice<CommentAndChildCommentCount> findCommentAndChildCommentCountBySpaceId(Long spaceId, Pageable pageable){
+        QComment subComment = new QComment("subComment");
+
+        List<CommentAndChildCommentCount> responses = queryFactory
+                .select(new QCommentAndChildCommentCount(
+                        comment,
+                        JPAExpressions
+                                .select(subComment.count())
+                                .from(subComment)
+                                .where(subComment.parentComment.id.eq(comment.id))
+                ))
+                .from(comment)
+                .where(comment.isDeleted.eq(false),
+                        comment.space.id.eq(spaceId),
+                        comment.parentComment.isNull())
+                .orderBy(comment.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = false;
+
+        if (responses.size() > pageable.getPageSize()) {
+            responses.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(responses, pageable, hasNext);
+    }
+
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/service/CommentService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/CommentService.java
@@ -38,6 +38,9 @@ public class CommentService {
 
     @Transactional(readOnly = true)
     public CommentAndChildCountResponses findRootComments(Long spaceId, Pageable pageable) {
+        Space space = spaceRepository.getById(spaceId);
+        space.validateCommentAvailability();
+
         Slice<CommentAndChildCommentCount> responses = commentRepository.findCommentAndChildCommentCountBySpaceId(spaceId, pageable);
 
         return CommentAndChildCountResponses.from(responses);

--- a/src/main/java/com/tenten/linkhub/domain/space/service/CommentService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/CommentService.java
@@ -3,9 +3,13 @@ package com.tenten.linkhub.domain.space.service;
 import com.tenten.linkhub.domain.space.model.space.Comment;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.repository.comment.CommentRepository;
+import com.tenten.linkhub.domain.space.repository.comment.dto.CommentAndChildCommentCount;
 import com.tenten.linkhub.domain.space.repository.space.SpaceRepository;
+import com.tenten.linkhub.domain.space.service.dto.comment.CommentAndChildCountResponses;
 import com.tenten.linkhub.domain.space.service.dto.comment.RootCommentCreateRequest;
 import com.tenten.linkhub.domain.space.service.mapper.CommentMapper;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +34,13 @@ public class CommentService {
 
         Comment comment = mapper.toComment(request, space);
         return commentRepository.save(comment).getId();
+    }
+
+    @Transactional(readOnly = true)
+    public CommentAndChildCountResponses findRootComments(Long spaceId, Pageable pageable) {
+        Slice<CommentAndChildCommentCount> responses = commentRepository.findCommentAndChildCommentCountBySpaceId(spaceId, pageable);
+
+        return CommentAndChildCountResponses.from(responses);
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/comment/CommentAndChildCountDto.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/comment/CommentAndChildCountDto.java
@@ -1,0 +1,9 @@
+package com.tenten.linkhub.domain.space.service.dto.comment;
+
+public record CommentAndChildCountDto(
+        Long commentId,
+        String content,
+        Long memberId,
+        Long childCount
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/comment/CommentAndChildCountDto.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/comment/CommentAndChildCountDto.java
@@ -1,8 +1,12 @@
 package com.tenten.linkhub.domain.space.service.dto.comment;
 
+import java.time.LocalDateTime;
+
 public record CommentAndChildCountDto(
         Long commentId,
         String content,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
         Long memberId,
         Long childCount
 ) {

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/comment/CommentAndChildCountResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/comment/CommentAndChildCountResponses.java
@@ -9,6 +9,8 @@ public record CommentAndChildCountResponses(Slice<CommentAndChildCountDto> respo
         Slice<CommentAndChildCountDto> mapResponses = responses.map(c -> new CommentAndChildCountDto(
                 c.comment().getId(),
                 c.comment().getContent(),
+                c.comment().getCreatedAt(),
+                c.comment().getUpdatedAt(),
                 c.comment().getMemberId(),
                 c.childCommentCount()
         ));

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/comment/CommentAndChildCountResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/comment/CommentAndChildCountResponses.java
@@ -1,0 +1,19 @@
+package com.tenten.linkhub.domain.space.service.dto.comment;
+
+import com.tenten.linkhub.domain.space.repository.comment.dto.CommentAndChildCommentCount;
+import org.springframework.data.domain.Slice;
+
+public record CommentAndChildCountResponses(Slice<CommentAndChildCountDto> responses) {
+
+    public static CommentAndChildCountResponses from(Slice<CommentAndChildCommentCount> responses){
+        Slice<CommentAndChildCountDto> mapResponses = responses.map(c -> new CommentAndChildCountDto(
+                c.comment().getId(),
+                c.comment().getContent(),
+                c.comment().getMemberId(),
+                c.childCommentCount()
+        ));
+
+        return new CommentAndChildCountResponses(mapResponses);
+    }
+
+}

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/CommentFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/CommentFacadeTest.java
@@ -4,7 +4,7 @@ import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
 import com.tenten.linkhub.domain.member.model.Provider;
-import com.tenten.linkhub.domain.member.repository.MemberJpaRepository;
+import com.tenten.linkhub.domain.member.repository.member.MemberJpaRepository;
 import com.tenten.linkhub.domain.space.facade.dto.CommentAndChildCountAndMemberInfo;
 import com.tenten.linkhub.domain.space.facade.dto.CommentAndChildCountAndMemberInfoResponses;
 import com.tenten.linkhub.domain.space.model.category.Category;
@@ -16,7 +16,6 @@ import com.tenten.linkhub.domain.space.model.space.SpaceMember;
 import com.tenten.linkhub.domain.space.repository.comment.CommentJpaRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
 import com.tenten.linkhub.global.exception.UnauthorizedAccessException;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -59,7 +58,7 @@ class CommentFacadeTest {
 
     @Test
     @DisplayName("유저는 루트 댓글들을 페이징 조회할 수 있다.")
-    void findRootComments(){
+    void findRootComments() {
         //given
         PageRequest pageRequest = PageRequest.of(0, 10);
 
@@ -81,7 +80,7 @@ class CommentFacadeTest {
 
     @Test
     @DisplayName("댓글을 달 수 없는 스페이스의 루트 댓글 페이지 조회 시 UnauthorizedAccessException가 발생한다. ")
-    void findRootComments_UnauthorizedAccessException(){
+    void findRootComments_UnauthorizedAccessException() {
         //given
         PageRequest pageRequest = PageRequest.of(0, 10);
 

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/CommentFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/CommentFacadeTest.java
@@ -1,0 +1,169 @@
+package com.tenten.linkhub.domain.space.facade;
+
+import com.tenten.linkhub.domain.member.model.FavoriteCategory;
+import com.tenten.linkhub.domain.member.model.Member;
+import com.tenten.linkhub.domain.member.model.ProfileImage;
+import com.tenten.linkhub.domain.member.model.Provider;
+import com.tenten.linkhub.domain.member.repository.MemberJpaRepository;
+import com.tenten.linkhub.domain.space.facade.dto.CommentAndChildCountAndMemberInfo;
+import com.tenten.linkhub.domain.space.facade.dto.CommentAndChildCountAndMemberInfoResponses;
+import com.tenten.linkhub.domain.space.model.category.Category;
+import com.tenten.linkhub.domain.space.model.space.Comment;
+import com.tenten.linkhub.domain.space.model.space.Role;
+import com.tenten.linkhub.domain.space.model.space.Space;
+import com.tenten.linkhub.domain.space.model.space.SpaceImage;
+import com.tenten.linkhub.domain.space.model.space.SpaceMember;
+import com.tenten.linkhub.domain.space.repository.comment.CommentJpaRepository;
+import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@TestPropertySource(locations = "classpath:/application-test.yml")
+@SpringBootTest
+class CommentFacadeTest {
+
+    @Autowired
+    private CommentFacade commentFacade;
+
+    @Autowired
+    private CommentJpaRepository commentJpaRepository;
+
+    @Autowired
+    private SpaceJpaRepository spaceJpaRepository;
+
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
+
+    private Long setUpSpaceId;
+    private Long setUpMemberId;
+
+    @BeforeEach
+    void setUp() {
+        setUpTestData();
+    }
+
+    @Test
+    @DisplayName("유저는 루트 댓글들을 페이징 조회할 수 있다.")
+    void findRootComments(){
+        //given
+        PageRequest pageRequest = PageRequest.of(0, 10);
+
+        //when
+        CommentAndChildCountAndMemberInfoResponses facadeResponses = commentFacade.findRootComments(setUpSpaceId, pageRequest);
+
+        //then
+        List<CommentAndChildCountAndMemberInfo> content = facadeResponses.responses().getContent();
+
+        assertThat(content.size()).isEqualTo(2);
+        assertThat(content.get(0).content()).isEqualTo("첫번째 루트 댓글");
+        assertThat(content.get(0).nickname()).isEqualTo("잠자는 사자의 콧털");
+        assertThat(content.get(0).profileImagePath()).isEqualTo("https://testprofileimage");
+        assertThat(content.get(0).childCount()).isEqualTo(2);
+        assertThat(content.get(1).content()).isEqualTo("두번째 루트 댓글");
+        assertThat(content.get(1).nickname()).isEqualTo("테스트 유저");
+        assertThat(content.get(1).childCount()).isEqualTo(1);
+    }
+
+    private void setUpTestData() {
+        Member member = new Member(
+                "testSocialId",
+                Provider.kakao,
+                com.tenten.linkhub.domain.member.model.Role.USER,
+                "잠자는 사자의 콧털",
+                "테스트용 소개글",
+                "abc@gmail.com",
+                true,
+                new ProfileImage("https://testprofileimage", "테스트용 멤버 프로필 이미지"),
+                new FavoriteCategory(Category.KNOWLEDGE_ISSUE_CAREER)
+        );
+        setUpMemberId = memberJpaRepository.save(member).getId();
+
+        Member member1 = new Member(
+                "testSocialId1",
+                Provider.kakao,
+                com.tenten.linkhub.domain.member.model.Role.USER,
+                "테스트 유저",
+                "테스트용 소개글1",
+                "abcde@gmail.com",
+                true,
+                new ProfileImage("https://testprofileimage1", "테스트용 멤버 프로필 이미지1"),
+                new FavoriteCategory(Category.KNOWLEDGE_ISSUE_CAREER)
+        );
+        Long setUpMemberId1 = memberJpaRepository.save(member1).getId();
+
+        Space space = new Space(
+                setUpMemberId,
+                "첫번째 스페이스",
+                "첫번째 스페이스 소개글",
+                Category.KNOWLEDGE_ISSUE_CAREER,
+                new SpaceImage("https://testimage1", "테스트 이미지1"),
+                new SpaceMember(setUpMemberId, Role.OWNER),
+                true,
+                true,
+                true,
+                true
+        );
+        setUpSpaceId = spaceJpaRepository.save(space).getId();
+
+        Comment comment1 = new Comment(
+                null,
+                null,
+                "첫번째 루트 댓글",
+                setUpMemberId,
+                space
+        );
+
+        Comment comment2 = new Comment(
+                null,
+                null,
+                "두번째 루트 댓글",
+                setUpMemberId1,
+                space
+        );
+
+        Comment savedComment1 = commentJpaRepository.save(comment1);
+        Comment savedComment2 = commentJpaRepository.save(comment2);
+
+        Comment childComment1 = new Comment(
+                savedComment1,
+                savedComment1.getId(),
+                "첫번째 루트 댓글의 대댓글1",
+                setUpMemberId1,
+                space
+        );
+
+        Comment childComment2 = new Comment(
+                savedComment1,
+                savedComment1.getId(),
+                "첫번째 루트 댓글의 대댓글2",
+                setUpMemberId,
+                space
+        );
+
+        Comment childComment3 = new Comment(
+                savedComment2,
+                savedComment2.getId(),
+                "두번째 루트 댓글의 대댓글1",
+                setUpMemberId,
+                space
+        );
+
+        commentJpaRepository.save(childComment1);
+        commentJpaRepository.save(childComment2);
+        commentJpaRepository.save(childComment3);
+
+    }
+
+}

--- a/src/test/java/com/tenten/linkhub/domain/space/service/CommentServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/CommentServiceTest.java
@@ -103,7 +103,7 @@ class CommentServiceTest {
         setUpMemberId = memberJpaRepository.save(member).getId();
 
         Space space1 = new Space(
-                1L,
+                setUpMemberId,
                 "첫번째 스페이스",
                 "첫번째 스페이스 소개글",
                 Category.KNOWLEDGE_ISSUE_CAREER,
@@ -116,7 +116,7 @@ class CommentServiceTest {
         );
 
         Space space2 = new Space(
-                1L,
+                setUpMemberId,
                 "두번째 스페이스",
                 "두번째 스페이스 소개글",
                 Category.ETC,


### PR DESCRIPTION
#48 
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 루트 댓글들 조회 API 구현 (페이지네이션)
  - 루트 댓글들 조회 시 대댓글 개수도 같이 전달.
- 해당 API 테스트 코드 작성.
- 스웨거 작성.