### PR TITLE
Feature/update link - 링크 수정 기능 구현

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
@@ -3,10 +3,12 @@ package com.tenten.linkhub.domain.space.controller;
 import com.tenten.linkhub.domain.auth.MemberDetails;
 import com.tenten.linkhub.domain.space.controller.dto.link.LinkCreateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.link.LinkCreateApiResponse;
+import com.tenten.linkhub.domain.space.controller.dto.link.LinkUpdateApiRequest;
+import com.tenten.linkhub.domain.space.controller.dto.link.LinkUpdateApiResponse;
 import com.tenten.linkhub.domain.space.controller.mapper.LinkApiMapper;
 import com.tenten.linkhub.domain.space.facade.LinkFacade;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
-import com.tenten.linkhub.domain.space.service.LinkService;
+import com.tenten.linkhub.domain.space.facade.dto.LinkUpdateFacadeRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
@@ -15,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,12 +27,10 @@ import java.net.URI;
 public class LinkController {
     private static final String LINK_LOCATION_PREFIX = "https://api.Link-hub.site/links/";
 
-    private final LinkService linkService;
     private final LinkFacade linkFacade;
     private final LinkApiMapper mapper;
 
-    public LinkController(LinkService linkService, LinkFacade linkFacade, LinkApiMapper mapper) {
-        this.linkService = linkService;
+    public LinkController(LinkFacade linkFacade, LinkApiMapper mapper) {
         this.linkFacade = linkFacade;
         this.mapper = mapper;
     }
@@ -62,6 +63,32 @@ public class LinkController {
         LinkCreateApiResponse response = mapper.toLinkCreateApiResponse(linkId);
         return ResponseEntity
                 .created(URI.create(LINK_LOCATION_PREFIX + response.linkId()))
+                .body(response);
+    }
+
+    /**
+     * 링크 수정 API
+     */
+    @PutMapping(value = "/spaces/{spaceId}/links/{linkId}",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<LinkUpdateApiResponse> updateLink(
+            @PathVariable long spaceId,
+            @PathVariable long linkId,
+            @Valid @RequestBody LinkUpdateApiRequest apiRequest,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        LinkUpdateFacadeRequest request = mapper.toLinkUpdateFacadeRequest(apiRequest);
+        long updateLinkId = linkFacade.updateLink(
+                spaceId,
+                linkId,
+                memberDetails.memberId(),
+                request
+        );
+
+        LinkUpdateApiResponse response = mapper.toLinkUpdateApiResponse(updateLinkId);
+        return ResponseEntity
+                .ok()
                 .body(response);
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
@@ -69,6 +69,15 @@ public class LinkController {
     /**
      * 링크 수정 API
      */
+    @Operation(
+            summary = "링크 수정 API",
+            description = "[JWT 필요] 스페이스 내에서 링크를 수정하는 API 입니다. Tag는 필수로 포함되어야 하는 값은 아닙니다. \n - Tag를 포함하여 링크를 수정하는 경우: tag 필드 포함. 단, \"\" 나 \" \"를 허용하지 않습니다.\n - Tag를 포함하지 않고 링크를 수하는 경우: 아예 tag 필드 없이 보내주세요",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "링크가 성공적으로 수정된 경우"),
+                    @ApiResponse(responseCode = "404", description = "링크 수정 권한이 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "요청한 spaceId에 해당하는 스페이스를 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "요청한 linkId에 해당하는 스페이스를 찾을 수 없습니다.")
+            })
     @PutMapping(value = "/spaces/{spaceId}/links/{linkId}",
             consumes = MediaType.APPLICATION_JSON_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkCreateApiRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkCreateApiRequest.java
@@ -1,17 +1,21 @@
 package com.tenten.linkhub.domain.space.controller.dto.link;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.URL;
 
 public record LinkCreateApiRequest(
+        @Schema(title = "링크 URL", example = "https://mideveloperni.tistory.com/")
         @NotBlank(message = "URL은 빈 값이 들어올 수 없습니다.")
         @URL(message = "적절한 URL 형식이 아닙니다.")
         String url,
 
+        @Schema(title = "링크 title", example = "개발 블로그 1")
         @NotBlank(message = "title은 빈 값이 들어올 수 없습니다.")
         String title,
 
+        @Schema(title = "링크 tag", example = "개발", description = "링크 생성 시 태그가 필요하면 tag 필드를 넣고, 태그 없이 링크를 생성한다면 아예 태그 필드를 제외하여 요청을 보내야 합니다.")
         @Pattern(regexp = "^(?!\\s*$).+", message = "태그는 비어있거나 공백만 있을 수 없습니다.")
         String tag
 ) {

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkUpdateApiRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkUpdateApiRequest.java
@@ -1,17 +1,21 @@
 package com.tenten.linkhub.domain.space.controller.dto.link;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.URL;
 
 public record LinkUpdateApiRequest(
+        @Schema(title = "링크 URL", example = "https://mideveloperni.tistory.com/")
         @NotBlank(message = "URL은 빈 값이 들어올 수 없습니다.")
         @URL(message = "적절한 URL 형식이 아닙니다.")
         String url,
 
+        @Schema(title = "링크 title", example = "개발 블로그 1")
         @NotBlank(message = "title은 빈 값이 들어올 수 없습니다.")
         String title,
 
+        @Schema(title = "링크 tag", example = "개발", description = "링크 생성 시 태그가 필요하면 tag 필드를 넣고, 태그 없이 링크를 생성한다면 아예 태그 필드를 제외하여 요청을 보내야 합니다.")
         @Pattern(regexp = "^(?!\\s*$).+", message = "태그는 비어있거나 공백만 있을 수 없습니다.")
         String tag
 ) {

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkUpdateApiRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkUpdateApiRequest.java
@@ -1,10 +1,10 @@
-package com.tenten.linkhub.domain.space.facade.dto;
+package com.tenten.linkhub.domain.space.controller.dto.link;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.URL;
 
-public record LinkCreateFacadeRequest(
+public record LinkUpdateApiRequest(
         @NotBlank(message = "URL은 빈 값이 들어올 수 없습니다.")
         @URL(message = "적절한 URL 형식이 아닙니다.")
         String url,

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkUpdateApiResponse.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkUpdateApiResponse.java
@@ -1,0 +1,6 @@
+package com.tenten.linkhub.domain.space.controller.dto.link;
+
+public record LinkUpdateApiResponse(
+        Long linkId
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/LinkApiMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/LinkApiMapper.java
@@ -2,9 +2,13 @@ package com.tenten.linkhub.domain.space.controller.mapper;
 
 import com.tenten.linkhub.domain.space.controller.dto.link.LinkCreateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.link.LinkCreateApiResponse;
+import com.tenten.linkhub.domain.space.controller.dto.link.LinkUpdateApiRequest;
+import com.tenten.linkhub.domain.space.controller.dto.link.LinkUpdateApiResponse;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
+import com.tenten.linkhub.domain.space.facade.dto.LinkUpdateFacadeRequest;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring",
         injectionStrategy = InjectionStrategy.CONSTRUCTOR
@@ -14,5 +18,10 @@ public interface LinkApiMapper {
     LinkCreateFacadeRequest toLinkCreateFacadeRequest(LinkCreateApiRequest apiRequest);
 
     LinkCreateApiResponse toLinkCreateApiResponse(Long linkId);
+
+    @Mapping(source = "updateLinkId", target = "linkId")
+    LinkUpdateApiResponse toLinkUpdateApiResponse(Long updateLinkId);
+
+    LinkUpdateFacadeRequest toLinkUpdateFacadeRequest(LinkUpdateApiRequest apiRequest);
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
@@ -1,10 +1,12 @@
 package com.tenten.linkhub.domain.space.facade;
 
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
+import com.tenten.linkhub.domain.space.facade.dto.LinkUpdateFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.mapper.LinkFacadeMapper;
 import com.tenten.linkhub.domain.space.service.LinkService;
 import com.tenten.linkhub.domain.space.service.SpaceService;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
+import com.tenten.linkhub.domain.space.service.dto.link.LinkUpdateRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,7 +25,7 @@ public class LinkFacade {
                            Long memberId,
                            LinkCreateFacadeRequest facadeRequest) {
 
-        spaceService.checkMemberAddLink(memberId, spaceId); //링크 생성 권한 확인
+        spaceService.checkMemberEditLink(memberId, spaceId); //링크 생성 권한 확인
 
         LinkCreateRequest request = mapper.toLinkCreateRequest(
                 facadeRequest,
@@ -31,5 +33,21 @@ public class LinkFacade {
                 spaceId
         );
         return linkService.createLink(request);
+    }
+
+    public long updateLink(long spaceId,
+                           long linkId,
+                           Long memberId,
+                           LinkUpdateFacadeRequest facadeRequest) {
+
+        spaceService.checkMemberEditLink(memberId, spaceId); //링크 수정 권한 확인
+
+        LinkUpdateRequest request = mapper.toLinkUpdateRequest(
+                facadeRequest,
+                memberId,
+                spaceId,
+                linkId
+        );
+        return linkService.updateLink(request);
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/dto/LinkUpdateFacadeRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/dto/LinkUpdateFacadeRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.URL;
 
-public record LinkCreateFacadeRequest(
+public record LinkUpdateFacadeRequest(
         @NotBlank(message = "URL은 빈 값이 들어올 수 없습니다.")
         @URL(message = "적절한 URL 형식이 아닙니다.")
         String url,

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/mapper/LinkFacadeMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/mapper/LinkFacadeMapper.java
@@ -1,7 +1,9 @@
 package com.tenten.linkhub.domain.space.facade.mapper;
 
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
+import com.tenten.linkhub.domain.space.facade.dto.LinkUpdateFacadeRequest;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
+import com.tenten.linkhub.domain.space.service.dto.link.LinkUpdateRequest;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -13,4 +15,9 @@ public interface LinkFacadeMapper {
     @Mapping(source = "spaceId", target = "spaceId")
     @Mapping(source = "memberId", target = "memberId")
     LinkCreateRequest toLinkCreateRequest(LinkCreateFacadeRequest request, Long memberId, Long spaceId);
+
+    @Mapping(source = "spaceId", target = "spaceId")
+    @Mapping(source = "memberId", target = "memberId")
+    @Mapping(source = "linkId", target = "linkId")
+    LinkUpdateRequest toLinkUpdateRequest(LinkUpdateFacadeRequest request, Long memberId, Long spaceId, Long linkId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/link/Link.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/link/Link.java
@@ -2,6 +2,7 @@ package com.tenten.linkhub.domain.space.model.link;
 
 import com.tenten.linkhub.domain.space.model.link.vo.Url;
 import com.tenten.linkhub.domain.space.model.space.Space;
+import com.tenten.linkhub.global.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static com.tenten.linkhub.global.util.CommonValidator.validateNotNull;
 
@@ -27,7 +29,7 @@ import static com.tenten.linkhub.global.util.CommonValidator.validateNotNull;
 @Table(name = "links")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Link {
+public class Link extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,7 +39,7 @@ public class Link {
     @JoinColumn(name = "space_id", nullable = false)
     private Space space;
 
-    @OneToMany(mappedBy = "link", cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "link", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<Tag> tags = new ArrayList<>();
 
     @Column(nullable = false)
@@ -88,4 +90,25 @@ public class Link {
         this.viewCount = 0L;
     }
 
+    public void updateLink(Url url, String title, Optional<Tag> tag) {
+        validateNotNull(url, "url");
+        validateNotNull(title, "title");
+        this.url = url;
+        this.title = title;
+
+        if (hasTag()) {
+            deleteTag();
+        }
+
+        tag.ifPresent(value -> this.tags.add(value));
+    }
+
+    private boolean hasTag() {
+        return !tags.isEmpty();
+    }
+
+    private void deleteTag() {
+        this.tags.forEach(Tag::deleteTag);
+        this.tags.clear();
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/link/Tag.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/link/Tag.java
@@ -43,6 +43,10 @@ public class Tag {
         this.link = link;
     }
 
+    public void deleteTag() {
+        this.link = null;
+    }
+
     private Tag(Space space, Link link, String name) {
         this.space = space;
         this.link = link;

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/DefaultLinkRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/DefaultLinkRepository.java
@@ -1,6 +1,7 @@
 package com.tenten.linkhub.domain.space.repository.link;
 
 import com.tenten.linkhub.domain.space.model.link.Link;
+import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +16,12 @@ public class DefaultLinkRepository implements LinkRepository {
     public Link save(Link link) {
         return linkJpaRepository.save(link);
     }
+
+    @Override
+    public Link getById(Long linkId) {
+        return linkJpaRepository
+                .findById(linkId)
+                .orElseThrow(() -> new EntityNotFoundException("linkId에 해당하는 link를 찾을 수 없습니다."));
+    }
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/DefaultLinkRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/DefaultLinkRepository.java
@@ -1,6 +1,7 @@
 package com.tenten.linkhub.domain.space.repository.link;
 
 import com.tenten.linkhub.domain.space.model.link.Link;
+import com.tenten.linkhub.global.exception.DataNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Repository;
 
@@ -21,7 +22,7 @@ public class DefaultLinkRepository implements LinkRepository {
     public Link getById(Long linkId) {
         return linkJpaRepository
                 .findById(linkId)
-                .orElseThrow(() -> new EntityNotFoundException("linkId에 해당하는 link를 찾을 수 없습니다."));
+                .orElseThrow(() -> new DataNotFoundException("linkId에 해당하는 link를 찾을 수 없습니다."));
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkJpaRepository.java
@@ -2,6 +2,13 @@ package com.tenten.linkhub.domain.space.repository.link;
 
 import com.tenten.linkhub.domain.space.model.link.Link;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
 
 public interface LinkJpaRepository extends JpaRepository<Link, Long> {
+
+    @Query("SELECT l from Link l WHERE l.id = :linkId AND l.isDeleted = false")
+    Optional<Link> findById(Long linkId);
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkRepository.java
@@ -5,6 +5,7 @@ import com.tenten.linkhub.domain.space.model.link.Link;
 public interface LinkRepository {
 
     Link save(Link link);
+
     Link getById(Long linkId);
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkRepository.java
@@ -3,5 +3,8 @@ package com.tenten.linkhub.domain.space.repository.link;
 import com.tenten.linkhub.domain.space.model.link.Link;
 
 public interface LinkRepository {
+
     Link save(Link link);
+    Link getById(Long linkId);
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
@@ -1,7 +1,5 @@
 package com.tenten.linkhub.domain.space.service;
 
-import static com.tenten.linkhub.domain.space.model.space.Role.OWNER;
-
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.repository.space.SpaceRepository;
 import com.tenten.linkhub.domain.space.repository.spacemember.SpaceMemberRepository;
@@ -17,6 +15,8 @@ import com.tenten.linkhub.global.exception.UnauthorizedAccessException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.tenten.linkhub.domain.space.model.space.Role.OWNER;
 
 @Service
 public class DefaultSpaceService implements SpaceService {
@@ -74,7 +74,7 @@ public class DefaultSpaceService implements SpaceService {
     }
 
     @Override
-    public void checkMemberAddLink(Long memberId, Long spaceId) {
+    public void checkMemberEditLink(Long memberId, Long spaceId) {
         if (!spaceMemberRepository.existsAuthorizedSpaceMember(memberId, spaceId)) {
             throw new UnauthorizedAccessException("링크를 생성할 수 있는 권한이 없습니다.");
         }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/LinkService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/LinkService.java
@@ -1,7 +1,11 @@
 package com.tenten.linkhub.domain.space.service;
 
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
+import com.tenten.linkhub.domain.space.service.dto.link.LinkUpdateRequest;
 
 public interface LinkService {
+
     Long createLink(LinkCreateRequest request);
+    Long updateLink(LinkUpdateRequest request);
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
@@ -18,7 +18,7 @@ public interface SpaceService {
 
     Long updateSpace(SpaceUpdateRequest spaceUpdateRequest);
 
-    void checkMemberAddLink(Long memberId, Long spaceId);
+    void checkMemberEditLink(Long memberId, Long spaceId);
 
     DeletedSpaceImageNames deleteSpaceById(Long spaceId, Long memberId);
 

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/LinkUpdateRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/LinkUpdateRequest.java
@@ -1,0 +1,11 @@
+package com.tenten.linkhub.domain.space.service.dto.link;
+
+public record LinkUpdateRequest(
+        Long spaceId,
+        String url,
+        String title,
+        String tag,
+        Long memberId,
+        Long linkId
+) {
+}

--- a/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
+++ b/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
@@ -68,7 +68,7 @@ public class GlobalApiExceptionHandler {
 
     @ExceptionHandler(DataDuplicateException.class)
     public ResponseEntity<ErrorWithDetailCodeResponse> handleDataDuplicateException(HttpServletRequest request,
-            DataDuplicateException e) {
+                                                                                    DataDuplicateException e) {
         ErrorWithDetailCodeResponse errorResponse = ErrorWithDetailCodeResponse.of(
                 e.getErrorCode(),
                 request.getRequestURI()

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
@@ -6,8 +6,10 @@ import com.tenten.linkhub.domain.member.model.ProfileImage;
 import com.tenten.linkhub.domain.member.model.Provider;
 import com.tenten.linkhub.domain.member.repository.MemberJpaRepository;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
+import com.tenten.linkhub.domain.space.facade.dto.LinkUpdateFacadeRequest;
 import com.tenten.linkhub.domain.space.model.category.Category;
 import com.tenten.linkhub.domain.space.model.link.Link;
+import com.tenten.linkhub.domain.space.model.link.vo.Url;
 import com.tenten.linkhub.domain.space.model.space.Role;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.model.space.SpaceImage;
@@ -48,6 +50,7 @@ class LinkFacadeTest {
     private Long memberId1;
     private Long memberId2;
     private Long spaceId;
+    private Long linkId;
 
     @BeforeEach
     void setUp() {
@@ -86,6 +89,41 @@ class LinkFacadeTest {
 
         //when
         Assertions.assertThatThrownBy(() -> linkFacade.createLink(spaceId, memberId2, request))
+                .isInstanceOf(UnauthorizedAccessException.class);
+    }
+
+    @Test
+    @DisplayName("사용자는 CAN_EDIT이나 OWNER 권한을 가진 경우 링크를 수정할 수 있다.")
+    void updateLink_request_Success() {
+        //given
+        LinkUpdateFacadeRequest request = new LinkUpdateFacadeRequest(
+                "https://naver2.com",
+                "수정할 링크의 제목",
+                "수정할 태그의 이름"
+        );
+
+        //when
+        Long updateLinkId = linkFacade.updateLink(spaceId, linkId, memberId1, request);
+
+        //then
+        Link link = linkJpaRepository.findById(linkId).get();
+        assertThat(link.getUrl().getUrl()).isEqualTo("https://naver2.com");
+        assertThat(link.getTitle()).isEqualTo("수정할 링크의 제목");
+        assertThat(link.getTags().get(0).getName()).isEqualTo("수정할 태그의 이름");
+    }
+
+    @Test
+    @DisplayName("사용자는 CAN_EDIT이나 OWNER 권한이 아닌 경우 링크를 수정할 수 없다.")
+    void updateLink_request_ThrowsUnauthorizedAccessException() {
+        //given
+        LinkUpdateFacadeRequest request = new LinkUpdateFacadeRequest(
+                "https://naver2.com",
+                "수정할 링크의 제목",
+                "수정할 태그의 이름"
+        );
+
+        //when
+        Assertions.assertThatThrownBy(() -> linkFacade.updateLink(spaceId, linkId, memberId2, request))
                 .isInstanceOf(UnauthorizedAccessException.class);
     }
 
@@ -142,5 +180,9 @@ class LinkFacadeTest {
         );
 
         spaceId = spaceJpaRepository.save(space).getId();
+
+        //링크 생성
+        Link link = Link.toLink(space, memberId1, "링크의 제목", new Url("https://www.naver.com"));
+        linkId = linkJpaRepository.save(link).getId();
     }
 }

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
@@ -15,6 +15,7 @@ import com.tenten.linkhub.domain.space.model.space.SpaceMember;
 import com.tenten.linkhub.domain.space.repository.link.LinkJpaRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
+import com.tenten.linkhub.domain.space.service.dto.link.LinkUpdateRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ public class DefaultLinkServiceTest {
 
     private Long memberId1;
     private Long spaceId;
+    private Long linkId;
 
     @BeforeEach
     void setUp() {
@@ -70,7 +72,30 @@ public class DefaultLinkServiceTest {
         assertThat(savedLink.getTitle()).isEqualTo("개발 블로그 1");
         assertThat(savedLink.getTags().get(0).getName()).isEqualTo("백엔드");
     }
-    
+
+    @Test
+    @DisplayName("사용자는 권한이 있는 경우 링크를 수정할 수 있다.")
+    void updateLink_request_Success() {
+        //given
+        LinkUpdateRequest request = new LinkUpdateRequest(
+                spaceId,
+                "https://mideveloperni2.tistory.com/",
+                "바꾼 타이틀",
+                "바꾼 태그",
+                memberId1,
+                linkId
+        );
+
+        //when
+        Long updatedLinkId = linkService.updateLink(request);
+
+        //then
+        Link savedLink = linkJpaRepository.findById(updatedLinkId).get();
+
+        assertThat(savedLink.getUrl()).usingRecursiveComparison().isEqualTo(new Url("https://mideveloperni2.tistory.com/"));
+        assertThat(savedLink.getTitle()).isEqualTo("바꾼 타이틀");
+        assertThat(savedLink.getTags().get(0).getName()).isEqualTo("바꾼 태그");
+    }
 
     private void setUpTestData() {
         Member member1 = new Member(
@@ -106,5 +131,9 @@ public class DefaultLinkServiceTest {
         );
 
         spaceId = spaceJpaRepository.save(space).getId();
+
+        //링크 생성
+        Link link = Link.toLink(space, memberId1, "링크의 제목", new Url("https://www.naver.com"));
+        linkId = linkJpaRepository.save(link).getId();
     }
 }

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
@@ -1,0 +1,110 @@
+package com.tenten.linkhub.domain.space.service;
+
+import com.tenten.linkhub.domain.member.model.FavoriteCategory;
+import com.tenten.linkhub.domain.member.model.Member;
+import com.tenten.linkhub.domain.member.model.ProfileImage;
+import com.tenten.linkhub.domain.member.model.Provider;
+import com.tenten.linkhub.domain.member.repository.MemberJpaRepository;
+import com.tenten.linkhub.domain.space.model.category.Category;
+import com.tenten.linkhub.domain.space.model.link.Link;
+import com.tenten.linkhub.domain.space.model.link.vo.Url;
+import com.tenten.linkhub.domain.space.model.space.Role;
+import com.tenten.linkhub.domain.space.model.space.Space;
+import com.tenten.linkhub.domain.space.model.space.SpaceImage;
+import com.tenten.linkhub.domain.space.model.space.SpaceMember;
+import com.tenten.linkhub.domain.space.repository.link.LinkJpaRepository;
+import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
+import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+public class DefaultLinkServiceTest {
+
+    @Autowired
+    private LinkService linkService;
+
+    @Autowired
+    private LinkJpaRepository linkJpaRepository;
+
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
+
+    @Autowired
+    private SpaceJpaRepository spaceJpaRepository;
+
+    private Long memberId1;
+    private Long spaceId;
+
+    @BeforeEach
+    void setUp() {
+        setUpTestData();
+    }
+
+    @Test
+    @DisplayName("사용자는 권한이 있는 경우 링크를 생성할 수 있다.")
+    void createLink_request_Success() {
+        //given
+        LinkCreateRequest request = new LinkCreateRequest(
+                spaceId,
+                "https://mideveloperni.tistory.com/",
+                "개발 블로그 1",
+                "백엔드",
+                memberId1
+        );
+
+        //when
+        Long savedLinkId = linkService.createLink(request);
+
+        //then
+        Link savedLink = linkJpaRepository.findById(savedLinkId).get();
+
+        assertThat(savedLink.getUrl()).usingRecursiveComparison().isEqualTo(new Url("https://mideveloperni.tistory.com/"));
+        assertThat(savedLink.getTitle()).isEqualTo("개발 블로그 1");
+        assertThat(savedLink.getTags().get(0).getName()).isEqualTo("백엔드");
+    }
+    
+
+    private void setUpTestData() {
+        Member member1 = new Member(
+                "123456",
+                Provider.kakao,
+                com.tenten.linkhub.domain.member.model.Role.USER,
+                "닉네임 데이터",
+                "소개 데이터",
+                "1111@gmail.com",
+                false,
+                new ProfileImage("https://testprofileimage", "테스트용 멤버 프로필 이미지1"),
+                new FavoriteCategory(Category.ENTER_ART)
+        );
+
+        memberId1 = memberJpaRepository.save(member1).getId();
+
+        //스페이스 생성 - member1
+        Space space = new Space(
+                memberId1,
+                "스페이스의 제목",
+                "스페이스 설명",
+                Category.ENTER_ART,
+                true,
+                true,
+                true,
+                true
+        );
+        space.addSpaceImage(
+                new SpaceImage("https://testimage1", "테스트 이미지1")
+        );
+        space.addSpaceMember(
+                new SpaceMember(memberId1, Role.OWNER)
+        );
+
+        spaceId = spaceJpaRepository.save(space).getId();
+    }
+}


### PR DESCRIPTION
## 이슈
#45 

## 🔗 구현 내용

### 링크 수정 API 구현
- Space 참가 권한을 확인한 후 `OWNER` 또는 `CAN_EDIT`이라면 링크를 수정할 수 있도록 구현했습니다.
- 링크 수정 관련 LinkFacadeTest 테스트 코드 작성, Link Service 테스트 코드 작성
- Swagger 코드 추가