### PR TITLE
Feature/get space tags - 스페이스에서 사용된 태그 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
@@ -260,8 +260,13 @@ public class SpaceController {
     }
 
     /**
-     * 스페이스에서 사용된 태그 목록 확인 API
+     * 스페이스에서 사용된 태그 목록 조회 API
      */
+    @Operation(
+            summary = "스페이스 내 태그 목록 조회 API", description = "스페이스 내 생성된 태그 목록을 조회하는 API 입니다. ",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "스페이스 내 생성된 태그 목록을 정상적으로 조회했습니다.")
+            })
     @GetMapping(value = "/{spaceId}/tags", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<SpaceTagsGetApiResponse> getSpaceTags(
             @AuthenticationPrincipal MemberDetails memberDetails,

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
@@ -8,6 +8,7 @@ import com.tenten.linkhub.domain.space.controller.dto.space.MySpacesFindApiRespo
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceCreateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceCreateApiResponse;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceDetailGetByIdApiResponse;
+import com.tenten.linkhub.domain.space.controller.dto.space.SpaceTagsGetApiResponse;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceUpdateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceUpdateApiResponse;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpacesFindByQueryApiRequest;
@@ -20,6 +21,7 @@ import com.tenten.linkhub.domain.space.facade.dto.SpaceDetailGetByIdFacadeRespon
 import com.tenten.linkhub.domain.space.service.CommentService;
 import com.tenten.linkhub.domain.space.service.SpaceService;
 import com.tenten.linkhub.domain.space.service.dto.comment.RootCommentCreateRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagsGetResponse;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryResponses;
 import com.tenten.linkhub.domain.space.util.SpaceViewList;
 import com.tenten.linkhub.global.response.ErrorResponse;
@@ -232,7 +234,7 @@ public class SpaceController {
     }
 
     /**
-     *  루트 댓글 생성 API
+     * 루트 댓글 생성 API
      */
     @Operation(
             summary = "루트 댓글 생성 API", description = "루트 댓글 생성 API 입니다.",
@@ -254,6 +256,21 @@ public class SpaceController {
 
         return ResponseEntity
                 .created(URI.create(SPACE_LOCATION_PRE_FIX + "/commments/" + savedCommentId))
+                .body(apiResponse);
+    }
+
+    /**
+     * 스페이스에서 사용된 태그 목록 확인 API
+     */
+    @GetMapping(value = "/{spaceId}/tags", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<SpaceTagsGetApiResponse> getSpaceTags(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @PathVariable Long spaceId
+    ) {
+        SpaceTagsGetResponse response = spaceService.getTagsBySpaceId(spaceId);
+        SpaceTagsGetApiResponse apiResponse = spaceMapper.toSpaceTagsGetApiResponse(response);
+        return ResponseEntity
+                .ok()
                 .body(apiResponse);
     }
 

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/space/SpaceTagsGetApiResponse.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/space/SpaceTagsGetApiResponse.java
@@ -1,0 +1,8 @@
+package com.tenten.linkhub.domain.space.controller.dto.space;
+
+import java.util.List;
+
+public record SpaceTagsGetApiResponse(
+        List<String> tagNames
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/SpaceApiMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/SpaceApiMapper.java
@@ -2,14 +2,15 @@ package com.tenten.linkhub.domain.space.controller.mapper;
 
 import com.tenten.linkhub.domain.space.controller.dto.MySpacesFindApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceCreateApiRequest;
+import com.tenten.linkhub.domain.space.controller.dto.space.SpaceTagsGetApiResponse;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceUpdateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpacesFindByQueryApiRequest;
 import com.tenten.linkhub.domain.space.facade.dto.SpaceCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.dto.SpaceDetailGetByIdFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.dto.SpaceUpdateFacadeRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.MySpacesFindRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagsGetResponse;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryRequest;
-import jakarta.servlet.http.Cookie;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.springframework.data.domain.Pageable;
@@ -31,4 +32,6 @@ public interface SpaceApiMapper {
     SpaceDetailGetByIdFacadeRequest toSpaceDetailGetByIdFacadeRequest(Long spaceId, Long memberId, List<Long> spaceViews);
 
     MySpacesFindRequest toMySpacesFindRequest(Pageable pageable, MySpacesFindApiRequest request, Long memberId);
+
+    SpaceTagsGetApiResponse toSpaceTagsGetApiResponse(SpaceTagsGetResponse response);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/tag/DefaultJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/tag/DefaultJpaRepository.java
@@ -2,6 +2,8 @@ package com.tenten.linkhub.domain.space.repository.tag;
 
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public class DefaultJpaRepository implements TagRepository {
 
@@ -9,5 +11,10 @@ public class DefaultJpaRepository implements TagRepository {
 
     public DefaultJpaRepository(TagJpaRepository tagJpaRepository) {
         this.tagJpaRepository = tagJpaRepository;
+    }
+
+    @Override
+    public List<String> findBySpaceIdAndGroupBySpaceName(Long spaceId) {
+        return tagJpaRepository.findBySpaceIdAndGroupBySpaceName(spaceId);
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/tag/TagJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/tag/TagJpaRepository.java
@@ -2,6 +2,11 @@ package com.tenten.linkhub.domain.space.repository.tag;
 
 import com.tenten.linkhub.domain.space.model.link.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface TagJpaRepository extends JpaRepository<Tag, Long> {
+    @Query("SELECT t.name FROM Tag t WHERE t.space.id = :spaceId GROUP BY t.name")
+    List<String> findBySpaceIdAndGroupBySpaceName(Long spaceId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/tag/TagRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/tag/TagRepository.java
@@ -1,5 +1,7 @@
 package com.tenten.linkhub.domain.space.repository.tag;
 
-public interface TagRepository {
+import java.util.List;
 
+public interface TagRepository {
+    List<String> findBySpaceIdAndGroupBySpaceName(Long spaceId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
@@ -5,9 +5,11 @@ import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
 import com.tenten.linkhub.domain.space.repository.space.SpaceRepository;
 import com.tenten.linkhub.domain.space.repository.spacemember.SpaceMemberRepository;
+import com.tenten.linkhub.domain.space.repository.tag.TagRepository;
 import com.tenten.linkhub.domain.space.service.dto.space.DeletedSpaceImageNames;
 import com.tenten.linkhub.domain.space.service.dto.space.MySpacesFindRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceCreateRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagsGetResponse;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceUpdateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceWithSpaceImageAndSpaceMemberInfo;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryRequest;
@@ -18,6 +20,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 import static com.tenten.linkhub.domain.space.model.space.Role.OWNER;
 
 @Service
@@ -26,11 +30,16 @@ public class DefaultSpaceService implements SpaceService {
     private final SpaceRepository spaceRepository;
     private final SpaceMapper mapper;
     private final SpaceMemberRepository spaceMemberRepository;
+    private final TagRepository tagRepository;
 
-    public DefaultSpaceService(SpaceRepository spaceRepository, SpaceMapper mapper, SpaceMemberRepository spaceMemberRepository) {
+    public DefaultSpaceService(SpaceRepository spaceRepository,
+                               SpaceMapper mapper,
+                               SpaceMemberRepository spaceMemberRepository,
+                               TagRepository tagRepository) {
         this.spaceRepository = spaceRepository;
         this.mapper = mapper;
         this.spaceMemberRepository = spaceMemberRepository;
+        this.tagRepository = tagRepository;
     }
 
     @Override
@@ -94,6 +103,12 @@ public class DefaultSpaceService implements SpaceService {
         Slice<Space> spaces = spaceRepository.findMySpacesJoinSpaceImageByQuery(mapper.toMySpacesFindQueryCondition(request));
 
         return SpacesFindByQueryResponses.from(spaces);
+    }
+
+    @Override
+    public SpaceTagsGetResponse getTagsBySpaceId(Long spaceId) {
+        List<String> tagNames = tagRepository.findBySpaceIdAndGroupBySpaceName(spaceId);
+        return SpaceTagsGetResponse.from(tagNames);
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
@@ -3,6 +3,7 @@ package com.tenten.linkhub.domain.space.service;
 import com.tenten.linkhub.domain.space.service.dto.space.DeletedSpaceImageNames;
 import com.tenten.linkhub.domain.space.service.dto.space.MySpacesFindRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceCreateRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagsGetResponse;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceUpdateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceWithSpaceImageAndSpaceMemberInfo;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryRequest;
@@ -23,4 +24,6 @@ public interface SpaceService {
     DeletedSpaceImageNames deleteSpaceById(Long spaceId, Long memberId);
 
     SpacesFindByQueryResponses findMySpacesByQuery(MySpacesFindRequest mySpacesFindRequest);
+
+    SpaceTagsGetResponse getTagsBySpaceId(Long spaceId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/space/SpaceTagsGetResponse.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/space/SpaceTagsGetResponse.java
@@ -1,0 +1,11 @@
+package com.tenten.linkhub.domain.space.service.dto.space;
+
+import java.util.List;
+
+public record SpaceTagsGetResponse(
+        List<String> tagNames
+) {
+    public static SpaceTagsGetResponse from(List<String> tagNames) {
+        return new SpaceTagsGetResponse(tagNames);
+    }
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/service/mapper/SpaceMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/mapper/SpaceMapper.java
@@ -60,7 +60,7 @@ public class SpaceMapper {
                 request.memberId());
     }
 
-    public SpaceUpdateDto toSpaceUpdateDto(SpaceUpdateRequest request){
+    public SpaceUpdateDto toSpaceUpdateDto(SpaceUpdateRequest request) {
         Optional<ImageInfo> imageInfo = request.imageInfo();
         Optional<SpaceImage> spaceImage = imageInfo.map(i -> new SpaceImage(i.path(), i.name()));
 
@@ -76,5 +76,4 @@ public class SpaceMapper {
                 spaceImage
         );
     }
-
 }

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
@@ -4,7 +4,7 @@ import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
 import com.tenten.linkhub.domain.member.model.Provider;
-import com.tenten.linkhub.domain.member.repository.MemberJpaRepository;
+import com.tenten.linkhub.domain.member.repository.member.MemberJpaRepository;
 import com.tenten.linkhub.domain.space.model.category.Category;
 import com.tenten.linkhub.domain.space.model.link.Link;
 import com.tenten.linkhub.domain.space.model.link.vo.Url;
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
-public class DefaultLinkServiceTest {
+class DefaultLinkServiceTest {
 
     @Autowired
     private LinkService linkService;
@@ -112,22 +112,18 @@ public class DefaultLinkServiceTest {
 
         memberId1 = memberJpaRepository.save(member1).getId();
 
-        //스페이스 생성 - member1
+        //스페이스 생성 - member1가 owner
         Space space = new Space(
                 memberId1,
                 "스페이스의 제목",
                 "스페이스 설명",
                 Category.ENTER_ART,
+                new SpaceImage("https://testimage1", "테스트 이미지1"),
+                new SpaceMember(memberId1, Role.OWNER),
                 true,
                 true,
                 true,
                 true
-        );
-        space.addSpaceImage(
-                new SpaceImage("https://testimage1", "테스트 이미지1")
-        );
-        space.addSpaceMember(
-                new SpaceMember(memberId1, Role.OWNER)
         );
 
         spaceId = spaceJpaRepository.save(space).getId();

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
@@ -5,6 +5,8 @@ import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
 import com.tenten.linkhub.domain.member.model.Provider;
 import com.tenten.linkhub.domain.member.repository.member.MemberJpaRepository;
+import com.tenten.linkhub.domain.space.facade.LinkFacade;
+import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.model.category.Category;
 import com.tenten.linkhub.domain.space.model.space.Role;
 import com.tenten.linkhub.domain.space.model.space.Space;
@@ -12,6 +14,7 @@ import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
 import com.tenten.linkhub.domain.space.service.dto.space.MySpacesFindRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagsGetResponse;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryResponse;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryResponses;
@@ -43,7 +46,11 @@ class DefaultSpaceServiceTest {
     @Autowired
     private MemberJpaRepository memberJpaRepository;
 
+    @Autowired
+    private LinkFacade linkFacade;
+
     private Long setUpMemberId;
+    private Long spaceId1;
 
     @BeforeEach
     void setUp() {
@@ -132,6 +139,23 @@ class DefaultSpaceServiceTest {
         assertThat(content.get(0).spaceImagePath()).isEqualTo("https://testimage2");
     }
 
+    @Test
+    @DisplayName("유저는 스페이스에서 사용된 태그 목록을 확인할 수 있다. - 링크 생성")
+    void getTagsBySpaceId_spaceId_Success() {
+        //given - 링크 생성 3개 생성 그 중 2개는 태그명이 같다.
+        Space space = spaceJpaRepository.findById(spaceId1).get();
+        linkFacade.createLink(spaceId1, setUpMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목A", "태그1"));
+        linkFacade.createLink(spaceId1, setUpMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목B", "태그1"));
+        linkFacade.createLink(spaceId1, setUpMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목C", "태그2"));
+
+        //when
+        SpaceTagsGetResponse response = spaceService.getTagsBySpaceId(spaceId1);
+
+        //then
+        assertThat(response.tagNames()).hasSize(2);
+        assertThat(response.tagNames()).containsExactlyInAnyOrderElementsOf(List.of("태그1", "태그2"));
+    }
+
     private void setupData() {
         Member member = new Member(
                 "testSocialId",
@@ -189,6 +213,8 @@ class DefaultSpaceServiceTest {
         spaceJpaRepository.save(space1);
         spaceJpaRepository.save(space2);
         spaceJpaRepository.save(space3);
+
+        spaceId1 = space1.getId();
     }
 
 }


### PR DESCRIPTION
## 이슈
#80 

## 🔗 구현 내용

### 스페이스에서 사용된 태그 목록 조회 기능 구현
- Space 내에서 사용되는 태그 목록을 조회하는 기능을 구현하였습니다. (GROUP BY 이용)
- DefaultSpaceServiceTest 내 테스트 코드 작성 (테스트 내용: 3개의 태그 중 2개의 태그명이 같고, 1개의 태그명이 다를 때 2개의 리스트를 반환하는지 확인)
- Swagger 코드 추가

### 해당 API 사용 예상 페이지
- 링크 생성 시 하단에 스페이스의 태그 리스팅
- 스페이스에 들어가서 링크들을 `태그` 기준으로 필터링 시 리스팅