### PR TITLE
Hotfix/create link - 태그 Color 추가에 따른 '링크 생성' 및 '링크 수정' API 수정

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkCreateApiRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkCreateApiRequest.java
@@ -17,6 +17,10 @@ public record LinkCreateApiRequest(
 
         @Schema(title = "링크 tag", example = "개발", description = "링크 생성 시 태그가 필요하면 tag 필드를 넣고, 태그 없이 링크를 생성한다면 아예 태그 필드를 제외하여 요청을 보내야 합니다.")
         @Pattern(regexp = "^(?!\\s*$).+", message = "태그는 비어있거나 공백만 있을 수 없습니다.")
-        String tag
+        String tag,
+
+        @Schema(title = "링크 tag의 색", example = "red", description = "미리 정의된 8가지 중 한가지 색을 입력해주세요.")
+        @NotBlank(message = "링크 tag의 색은 빈 값이 들어올 수 없습니다.")
+        String color
 ) {
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkUpdateApiRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/LinkUpdateApiRequest.java
@@ -17,6 +17,10 @@ public record LinkUpdateApiRequest(
 
         @Schema(title = "링크 tag", example = "개발", description = "링크 생성 시 태그가 필요하면 tag 필드를 넣고, 태그 없이 링크를 생성한다면 아예 태그 필드를 제외하여 요청을 보내야 합니다.")
         @Pattern(regexp = "^(?!\\s*$).+", message = "태그는 비어있거나 공백만 있을 수 없습니다.")
-        String tag
+        String tag,
+
+        @Schema(title = "링크 tag의 색", example = "red", description = "미리 정의된 8가지 중 한가지 색을 입력해주세요.")
+        @NotBlank(message = "링크 tag의 색은 빈 값이 들어올 수 없습니다.")
+        String color
 ) {
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/LinkApiMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/LinkApiMapper.java
@@ -6,15 +6,18 @@ import com.tenten.linkhub.domain.space.controller.dto.link.LinkUpdateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.link.LinkUpdateApiResponse;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.dto.LinkUpdateFacadeRequest;
+import com.tenten.linkhub.domain.space.model.link.Color;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring",
         injectionStrategy = InjectionStrategy.CONSTRUCTOR
 )
 public interface LinkApiMapper {
 
+    @Mapping(target = "color", source = "color", qualifiedByName = "toColor")
     LinkCreateFacadeRequest toLinkCreateFacadeRequest(LinkCreateApiRequest apiRequest);
 
     LinkCreateApiResponse toLinkCreateApiResponse(Long linkId);
@@ -22,6 +25,16 @@ public interface LinkApiMapper {
     @Mapping(source = "updateLinkId", target = "linkId")
     LinkUpdateApiResponse toLinkUpdateApiResponse(Long updateLinkId);
 
+    @Mapping(target = "color", source = "color", qualifiedByName = "toColor")
     LinkUpdateFacadeRequest toLinkUpdateFacadeRequest(LinkUpdateApiRequest apiRequest);
 
+    @Named("toColor")
+    static Color toColor(String tag) {
+        for (Color color : Color.values()) {
+            if (color.getValue().equals(tag)) {
+                return color;
+            }
+        }
+        throw new IllegalArgumentException("정의된 태그의 색이 아닙니다.");
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/dto/LinkCreateFacadeRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/dto/LinkCreateFacadeRequest.java
@@ -1,6 +1,8 @@
 package com.tenten.linkhub.domain.space.facade.dto;
 
+import com.tenten.linkhub.domain.space.model.link.Color;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.URL;
 
@@ -13,6 +15,9 @@ public record LinkCreateFacadeRequest(
         String title,
 
         @Pattern(regexp = "^(?!\\s*$).+", message = "태그는 비어있거나 공백만 있을 수 없습니다.")
-        String tag
+        String tag,
+
+        @NotNull(message = "링크 tag의 색은 빈 값이 들어올 수 없습니다.")
+        Color color
 ) {
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/dto/LinkUpdateFacadeRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/dto/LinkUpdateFacadeRequest.java
@@ -1,6 +1,8 @@
 package com.tenten.linkhub.domain.space.facade.dto;
 
+import com.tenten.linkhub.domain.space.model.link.Color;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import org.hibernate.validator.constraints.URL;
 
@@ -13,6 +15,9 @@ public record LinkUpdateFacadeRequest(
         String title,
 
         @Pattern(regexp = "^(?!\\s*$).+", message = "태그는 비어있거나 공백만 있을 수 없습니다.")
-        String tag
+        String tag,
+
+        @NotNull(message = "링크 tag의 색은 빈 값이 들어올 수 없습니다.")
+        Color color
 ) {
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/link/Color.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/link/Color.java
@@ -1,0 +1,23 @@
+package com.tenten.linkhub.domain.space.model.link;
+
+public enum Color {
+
+    EMERALD("emerald"),
+    RED("red"),
+    YELLOW("yellow"),
+    BLUE("blue"),
+    INDIGO("indigo"),
+    PURPLE("purple"),
+    PINK("pink"),
+    GRAY("gray");
+
+    private final String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    Color(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/model/link/Tag.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/link/Tag.java
@@ -3,6 +3,8 @@ package com.tenten.linkhub.domain.space.model.link;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -35,8 +37,14 @@ public class Tag {
     @Column(nullable = false)
     private String name;
 
-    public static Tag toTag(Space space, Link link, String name) {
-        return new Tag(space, link, name);
+    @Enumerated(EnumType.STRING)
+    private Color color;
+
+    public static Tag toTag(Space space,
+                            Link link,
+                            String name,
+                            Color color) {
+        return new Tag(space, link, name, color);
     }
 
     public void changeLink(Link link) {
@@ -47,10 +55,11 @@ public class Tag {
         this.link = null;
     }
 
-    private Tag(Space space, Link link, String name) {
+    private Tag(Space space, Link link, String name, Color color) {
         this.space = space;
         this.link = link;
         this.name = name;
+        this.color = color;
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultLinkService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultLinkService.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.domain.space.model.link.Color;
 import com.tenten.linkhub.domain.space.model.link.Link;
 import com.tenten.linkhub.domain.space.model.link.Tag;
 import com.tenten.linkhub.domain.space.model.link.vo.Url;
@@ -40,7 +41,7 @@ public class DefaultLinkService implements LinkService {
                 new Url(request.url()));
 
         if (Objects.nonNull(request.tag())) {
-            Tag tag = Tag.toTag(space, link, request.tag());
+            Tag tag = Tag.toTag(space, link, request.tag(), request.color());
             link.addTag(tag);
         }
         return linkRepository.save(link).getId();
@@ -51,16 +52,16 @@ public class DefaultLinkService implements LinkService {
     public Long updateLink(LinkUpdateRequest request) {
         Space space = spaceRepository.getById(request.spaceId());
         Link link = linkRepository.getById(request.linkId());
-        Optional<Tag> tag = toTag(space, link, request.tag());
+        Optional<Tag> tag = toTag(space, link, request.tag(), request.color());
 
         link.updateLink(new Url(request.url()), request.title(), tag);
 
         return link.getId();
     }
 
-    private Optional<Tag> toTag(Space space, Link link, String tagName) {
+    private Optional<Tag> toTag(Space space, Link link, String tagName, Color color) {
         if (Objects.nonNull(tagName)) {
-            return Optional.of(Tag.toTag(space, link, tagName));
+            return Optional.of(Tag.toTag(space, link, tagName, color));
         }
         return Optional.empty();
     }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/LinkCreateRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/LinkCreateRequest.java
@@ -1,10 +1,13 @@
 package com.tenten.linkhub.domain.space.service.dto.link;
 
+import com.tenten.linkhub.domain.space.model.link.Color;
+
 public record LinkCreateRequest(
         Long spaceId,
         String url,
         String title,
         String tag,
-        Long memberId
+        Long memberId,
+        Color color
 ) {
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/LinkUpdateRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/LinkUpdateRequest.java
@@ -1,11 +1,14 @@
 package com.tenten.linkhub.domain.space.service.dto.link;
 
+import com.tenten.linkhub.domain.space.model.link.Color;
+
 public record LinkUpdateRequest(
         Long spaceId,
         String url,
         String title,
         String tag,
         Long memberId,
-        Long linkId
+        Long linkId,
+        Color color
 ) {
 }

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
@@ -8,6 +8,7 @@ import com.tenten.linkhub.domain.member.repository.member.MemberJpaRepository;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.dto.LinkUpdateFacadeRequest;
 import com.tenten.linkhub.domain.space.model.category.Category;
+import com.tenten.linkhub.domain.space.model.link.Color;
 import com.tenten.linkhub.domain.space.model.link.Link;
 import com.tenten.linkhub.domain.space.model.link.vo.Url;
 import com.tenten.linkhub.domain.space.model.space.Role;
@@ -64,7 +65,8 @@ class LinkFacadeTest {
         LinkCreateFacadeRequest request = new LinkCreateFacadeRequest(
                 "https://naver.com",
                 "링크의 제목",
-                "태그의 이름"
+                "태그의 이름",
+                Color.RED
         );
 
         //when
@@ -84,7 +86,8 @@ class LinkFacadeTest {
         LinkCreateFacadeRequest request = new LinkCreateFacadeRequest(
                 "https://naver.com",
                 "링크의 제목",
-                "태그의 이름"
+                "태그의 이름",
+                Color.EMERALD
         );
 
         //when
@@ -99,7 +102,8 @@ class LinkFacadeTest {
         LinkUpdateFacadeRequest request = new LinkUpdateFacadeRequest(
                 "https://naver2.com",
                 "수정할 링크의 제목",
-                "수정할 태그의 이름"
+                "수정할 태그의 이름",
+                Color.GRAY
         );
 
         //when
@@ -119,7 +123,8 @@ class LinkFacadeTest {
         LinkUpdateFacadeRequest request = new LinkUpdateFacadeRequest(
                 "https://naver2.com",
                 "수정할 링크의 제목",
-                "수정할 태그의 이름"
+                "수정할 태그의 이름",
+                Color.BLUE
         );
 
         //when

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
@@ -6,6 +6,7 @@ import com.tenten.linkhub.domain.member.model.ProfileImage;
 import com.tenten.linkhub.domain.member.model.Provider;
 import com.tenten.linkhub.domain.member.repository.member.MemberJpaRepository;
 import com.tenten.linkhub.domain.space.model.category.Category;
+import com.tenten.linkhub.domain.space.model.link.Color;
 import com.tenten.linkhub.domain.space.model.link.Link;
 import com.tenten.linkhub.domain.space.model.link.vo.Url;
 import com.tenten.linkhub.domain.space.model.space.Role;
@@ -59,7 +60,8 @@ class DefaultLinkServiceTest {
                 "https://mideveloperni.tistory.com/",
                 "개발 블로그 1",
                 "백엔드",
-                memberId1
+                memberId1,
+                Color.BLUE
         );
 
         //when
@@ -83,7 +85,8 @@ class DefaultLinkServiceTest {
                 "바꾼 타이틀",
                 "바꾼 태그",
                 memberId1,
-                linkId
+                linkId,
+                Color.GRAY
         );
 
         //when

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
@@ -8,6 +8,7 @@ import com.tenten.linkhub.domain.member.repository.member.MemberJpaRepository;
 import com.tenten.linkhub.domain.space.facade.LinkFacade;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.model.category.Category;
+import com.tenten.linkhub.domain.space.model.link.Color;
 import com.tenten.linkhub.domain.space.model.space.Role;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.model.space.SpaceImage;
@@ -144,9 +145,9 @@ class DefaultSpaceServiceTest {
     void getTagsBySpaceId_spaceId_Success() {
         //given - 링크 생성 3개 생성 그 중 2개는 태그명이 같다.
         Space space = spaceJpaRepository.findById(spaceId1).get();
-        linkFacade.createLink(spaceId1, setUpMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목A", "태그1"));
-        linkFacade.createLink(spaceId1, setUpMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목B", "태그1"));
-        linkFacade.createLink(spaceId1, setUpMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목C", "태그2"));
+        linkFacade.createLink(spaceId1, setUpMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목A", "태그1", Color.BLUE));
+        linkFacade.createLink(spaceId1, setUpMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목B", "태그1", Color.GRAY));
+        linkFacade.createLink(spaceId1, setUpMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목C", "태그2", Color.RED));
 
         //when
         SpaceTagsGetResponse response = spaceService.getTagsBySpaceId(spaceId1);


### PR DESCRIPTION
## 이슈
#90 

## 🔗 구현 내용

### 링크 생성 및 수정 API 수정
- Tag 엔티티 내 Color(Enum) 필드 추가
- 링크 생성 API의 Request에 color 추가
- 링크 수정 API의 Request에 color 추가
- 코드 수정에 따른 테스트코드 갱신(수정)작업