### PR TITLE
Feat/link 링크 좋아요 및 좋아요 취소 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.retry:spring-retry:2.0.3'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
@@ -1,18 +1,22 @@
 package com.tenten.linkhub.domain.space.controller;
 
 import com.tenten.linkhub.domain.auth.MemberDetails;
+import com.tenten.linkhub.domain.space.controller.dto.like.LikeCreateApiResponse;
 import com.tenten.linkhub.domain.space.controller.dto.link.LinkCreateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.link.LinkCreateApiResponse;
 import com.tenten.linkhub.domain.space.controller.mapper.LinkApiMapper;
 import com.tenten.linkhub.domain.space.facade.LinkFacade;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
-import com.tenten.linkhub.domain.space.service.LinkService;
+import com.tenten.linkhub.global.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,12 +28,10 @@ import java.net.URI;
 public class LinkController {
     private static final String LINK_LOCATION_PREFIX = "https://api.Link-hub.site/links/";
 
-    private final LinkService linkService;
     private final LinkFacade linkFacade;
     private final LinkApiMapper mapper;
 
-    public LinkController(LinkService linkService, LinkFacade linkFacade, LinkApiMapper mapper) {
-        this.linkService = linkService;
+    public LinkController(LinkFacade linkFacade, LinkApiMapper mapper) {
         this.linkFacade = linkFacade;
         this.mapper = mapper;
     }
@@ -63,5 +65,45 @@ public class LinkController {
         return ResponseEntity
                 .created(URI.create(LINK_LOCATION_PREFIX + response.linkId()))
                 .body(response);
+    }
+
+    /**
+     * 링크 좋아요 API
+     */
+    @Operation(
+            summary = "링크 좋아요 API",
+            description = "[JWT 필요] 링크에 좋아요를 누르는 기능입니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "좋아요가 성공한 경우"),
+                    @ApiResponse(responseCode = "404", description = "이미 좋아요한 링크인 경우 또는 존재하지 않는 링크인 경우",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            })
+    @PostMapping(value = "/links/{linkId}/like", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<LikeCreateApiResponse> createLike(
+            @PathVariable Long linkId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        Boolean isLiked = linkFacade.createLike(linkId, memberDetails.memberId());
+
+        return ResponseEntity.ok().body(LikeCreateApiResponse.from(isLiked));
+    }
+
+    /**
+     * 링크 좋아요 취소 API
+     */
+    @Operation(
+            summary = "링크 좋아요 취소 API",
+            description = "[JWT 필요] 링크에 누른 좋아요를 취소하는 기능입니다.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "좋아요 취소를 성공한 경우"),
+            })
+    @DeleteMapping(value = "/links/{linkId}/like", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Void> cancelLike(
+            @PathVariable Long linkId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        linkFacade.cancelLike(linkId, memberDetails.memberId());
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/like/LikeCreateApiResponse.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/like/LikeCreateApiResponse.java
@@ -1,0 +1,7 @@
+package com.tenten.linkhub.domain.space.controller.dto.like;
+
+public record LikeCreateApiResponse(Boolean isLiked) {
+    public static LikeCreateApiResponse from(Boolean isLiked) {
+        return new LikeCreateApiResponse(isLiked);
+    }
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
@@ -2,9 +2,12 @@ package com.tenten.linkhub.domain.space.facade;
 
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.mapper.LinkFacadeMapper;
+import com.tenten.linkhub.domain.space.handler.dto.LinkDecreaseLikeCountDto;
+import com.tenten.linkhub.domain.space.handler.dto.LinkIncreaseLikeCountDto;
 import com.tenten.linkhub.domain.space.service.LinkService;
 import com.tenten.linkhub.domain.space.service.SpaceService;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,11 +15,13 @@ public class LinkFacade {
     private final SpaceService spaceService;
     private final LinkService linkService;
     private final LinkFacadeMapper mapper;
+    private final ApplicationEventPublisher eventPublisher;
 
-    public LinkFacade(SpaceService spaceService, LinkService linkService, LinkFacadeMapper mapper) {
+    public LinkFacade(SpaceService spaceService, LinkService linkService, LinkFacadeMapper mapper, ApplicationEventPublisher eventPublisher) {
         this.spaceService = spaceService;
         this.linkService = linkService;
         this.mapper = mapper;
+        this.eventPublisher = eventPublisher;
     }
 
     public Long createLink(Long spaceId,
@@ -31,5 +36,23 @@ public class LinkFacade {
                 spaceId
         );
         return linkService.createLink(request);
+    }
+
+    public Boolean createLike(Long linkId, Long memberId) {
+        Boolean isLiked = linkService.createLike(linkId, memberId);
+
+        eventPublisher.publishEvent(
+                new LinkIncreaseLikeCountDto(linkId)
+        );
+
+        return isLiked;
+    }
+
+    public void cancelLike(Long linkId, Long memberId) {
+        linkService.cancelLike(linkId, memberId);
+
+        eventPublisher.publishEvent(
+                new LinkDecreaseLikeCountDto(linkId)
+        );
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/LinkEventHandler.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/LinkEventHandler.java
@@ -1,0 +1,51 @@
+package com.tenten.linkhub.domain.space.handler;
+
+import com.tenten.linkhub.domain.space.handler.dto.LinkDecreaseLikeCountDto;
+import com.tenten.linkhub.domain.space.handler.dto.LinkIncreaseLikeCountDto;
+import com.tenten.linkhub.domain.space.model.link.Link;
+import com.tenten.linkhub.domain.space.repository.link.LinkRepository;
+import jakarta.persistence.OptimisticLockException;
+import org.springframework.context.event.EventListener;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class LinkEventHandler {
+
+    private final LinkRepository linkRepository;
+
+    public LinkEventHandler(LinkRepository linkRepository) {
+        this.linkRepository = linkRepository;
+    }
+
+    @Async
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+            retryFor = OptimisticLockException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
+    public void increaseLikeCount(LinkIncreaseLikeCountDto linkIncreaseLikeCountDto) {
+        linkRepository.findById(linkIncreaseLikeCountDto.linkId())
+                .ifPresent(Link::increaseLikeCount);
+    }
+
+    @Async
+    @EventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Retryable(
+            retryFor = OptimisticLockException.class,
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
+    public void decreaseLikeCount(LinkDecreaseLikeCountDto linkDecreaseLikeCountDto) {
+        linkRepository.findById(linkDecreaseLikeCountDto.linkId())
+                .ifPresent(Link::decreaseLikeCount);
+    }
+
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/dto/LinkDecreaseLikeCountDto.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/dto/LinkDecreaseLikeCountDto.java
@@ -1,0 +1,4 @@
+package com.tenten.linkhub.domain.space.handler.dto;
+
+public record LinkDecreaseLikeCountDto(Long linkId) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/dto/LinkIncreaseLikeCountDto.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/dto/LinkIncreaseLikeCountDto.java
@@ -1,0 +1,4 @@
+package com.tenten.linkhub.domain.space.handler.dto;
+
+public record LinkIncreaseLikeCountDto(Long linkId) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/model/link/Like.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/link/Like.java
@@ -9,12 +9,17 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "likes")
+@Table(name = "likes", uniqueConstraints = {
+        @UniqueConstraint(
+                name = "like_unique",
+                columnNames = {"memberId", "link_id"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Like {
@@ -29,5 +34,10 @@ public class Like {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "link_id", nullable = false)
     private Link link;
+
+    public Like(Link link, Long memberId) {
+        this.link = link;
+        this.memberId = memberId;
+    }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/link/Link.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/link/Link.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -55,6 +56,9 @@ public class Link {
     @Column(nullable = false)
     private Long likeCount;
 
+    @Version
+    private int version;
+
     public void addTag(Tag tag) {
         tags.add(tag);
         tag.changeLink(this);
@@ -88,4 +92,11 @@ public class Link {
         this.viewCount = 0L;
     }
 
+    public void increaseLikeCount() {
+        likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        likeCount--;
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/like/DefaultLikeJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/like/DefaultLikeJpaRepository.java
@@ -1,0 +1,31 @@
+package com.tenten.linkhub.domain.space.repository.like;
+
+import com.tenten.linkhub.domain.space.model.link.Like;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class DefaultLikeJpaRepository implements LikeRepository {
+
+    private final LikeJpaRepository likeJpaRepository;
+
+    public DefaultLikeJpaRepository(LikeJpaRepository likeJpaRepository) {
+        this.likeJpaRepository = likeJpaRepository;
+    }
+
+    @Override
+    public Optional<Like> findByLinkIdAndMemberId(Long linkId, Long memberId) {
+        return likeJpaRepository.findByLinkIdAndMemberId(linkId, memberId);
+    }
+
+    @Override
+    public Like save(Like like) {
+        return likeJpaRepository.save(like);
+    }
+
+    @Override
+    public void delete(Like like) {
+        likeJpaRepository.delete(like);
+    }
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/like/LikeJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/like/LikeJpaRepository.java
@@ -1,0 +1,12 @@
+package com.tenten.linkhub.domain.space.repository.like;
+
+import com.tenten.linkhub.domain.space.model.link.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface LikeJpaRepository extends JpaRepository<Like, Long> {
+    @Query("SELECT l FROM Like l WHERE l.link.id = :linkId AND l.memberId = :memberId")
+    Optional<Like> findByLinkIdAndMemberId(Long linkId, Long memberId);
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/like/LikeRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/like/LikeRepository.java
@@ -1,0 +1,14 @@
+package com.tenten.linkhub.domain.space.repository.like;
+
+import com.tenten.linkhub.domain.space.model.link.Like;
+
+import java.util.Optional;
+
+public interface LikeRepository {
+
+    Optional<Like> findByLinkIdAndMemberId(Long linkId, Long memberId);
+
+    Like save(Like like);
+
+    void delete(Like like);
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/DefaultLinkRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/DefaultLinkRepository.java
@@ -3,6 +3,8 @@ package com.tenten.linkhub.domain.space.repository.link;
 import com.tenten.linkhub.domain.space.model.link.Link;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public class DefaultLinkRepository implements LinkRepository {
     private final LinkJpaRepository linkJpaRepository;
@@ -14,5 +16,10 @@ public class DefaultLinkRepository implements LinkRepository {
     @Override
     public Link save(Link link) {
         return linkJpaRepository.save(link);
+    }
+
+    @Override
+    public Optional<Link> findById(Long linkId) {
+        return linkJpaRepository.findById(linkId);
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkRepository.java
@@ -2,6 +2,10 @@ package com.tenten.linkhub.domain.space.repository.link;
 
 import com.tenten.linkhub.domain.space.model.link.Link;
 
+import java.util.Optional;
+
 public interface LinkRepository {
     Link save(Link link);
+
+    Optional<Link> findById(Long linkId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultLinkService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultLinkService.java
@@ -1,27 +1,35 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.domain.space.model.link.Like;
 import com.tenten.linkhub.domain.space.model.link.Link;
 import com.tenten.linkhub.domain.space.model.link.Tag;
 import com.tenten.linkhub.domain.space.model.link.vo.Url;
 import com.tenten.linkhub.domain.space.model.space.Space;
+import com.tenten.linkhub.domain.space.repository.like.LikeRepository;
 import com.tenten.linkhub.domain.space.repository.link.LinkRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceRepository;
 import com.tenten.linkhub.domain.space.repository.tag.TagRepository;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
+import com.tenten.linkhub.global.exception.DataNotFoundException;
+import com.tenten.linkhub.global.exception.UnauthorizedAccessException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 public class DefaultLinkService implements LinkService {
     private final LinkRepository linkRepository;
     private final TagRepository tagRepository;
     private final SpaceRepository spaceRepository;
+    private final LikeRepository likeRepository;
 
-    public DefaultLinkService(LinkRepository linkRepository, TagRepository tagRepository, SpaceRepository spaceRepository) {
+    public DefaultLinkService(LinkRepository linkRepository, TagRepository tagRepository, SpaceRepository spaceRepository, LikeRepository likeRepository) {
         this.linkRepository = linkRepository;
         this.tagRepository = tagRepository;
         this.spaceRepository = spaceRepository;
+        this.likeRepository = likeRepository;
     }
 
     @Override
@@ -39,5 +47,29 @@ public class DefaultLinkService implements LinkService {
             link.addTag(tag);
         }
         return linkRepository.save(link).getId();
+    }
+
+    @Override
+    @Transactional
+    public Boolean createLike(Long linkId, Long memberId) {
+        Link link = linkRepository.findById(linkId)
+                .orElseThrow(() -> new DataNotFoundException("존재하지 않는 링크입니다."));
+
+        likeRepository.findByLinkIdAndMemberId(linkId, memberId)
+                .ifPresent(m -> {
+                    throw new UnauthorizedAccessException("이미 좋아요한 링크입니다.");
+                });
+
+        likeRepository.save(new Like(link, memberId));
+
+        return true;
+    }
+
+    @Override
+    @Transactional
+    public void cancelLike(Long linkId, Long memberId) {
+        Optional<Like> like = likeRepository.findByLinkIdAndMemberId(linkId, memberId);
+
+        like.ifPresent(likeRepository::delete);
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/LinkService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/LinkService.java
@@ -4,4 +4,8 @@ import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
 
 public interface LinkService {
     Long createLink(LinkCreateRequest request);
+
+    Boolean createLike(Long linkId, Long memberId);
+
+    void cancelLike(Long linkId, Long memberId);
 }

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
@@ -103,10 +103,11 @@ class LinkFacadeTest {
     @DisplayName("좋아요에 성공한다.")
     void createLike_request_Success() {
         //given & when
-        Boolean isLiked = linkFacade.createLike(linkId, memberId1);
+        linkFacade.createLike(linkId, memberId1);
 
         //then
-        assertThat(isLiked).isTrue();
+        Optional<Like> like = likeJpaRepository.findByLinkIdAndMemberId(linkId, memberId1);
+        assertThat(like).isPresent();
     }
 
     @Test

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
@@ -7,14 +7,18 @@ import com.tenten.linkhub.domain.member.model.Provider;
 import com.tenten.linkhub.domain.member.repository.member.MemberJpaRepository;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.model.category.Category;
+import com.tenten.linkhub.domain.space.model.link.Like;
 import com.tenten.linkhub.domain.space.model.link.Link;
+import com.tenten.linkhub.domain.space.model.link.vo.Url;
 import com.tenten.linkhub.domain.space.model.space.Role;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
+import com.tenten.linkhub.domain.space.repository.like.LikeJpaRepository;
 import com.tenten.linkhub.domain.space.repository.link.LinkJpaRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
 import com.tenten.linkhub.domain.space.repository.spacemember.SpaceMemberJpaRepository;
+import com.tenten.linkhub.global.exception.DataNotFoundException;
 import com.tenten.linkhub.global.exception.UnauthorizedAccessException;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,9 +51,13 @@ class LinkFacadeTest {
     @Autowired
     private LinkJpaRepository linkJpaRepository;
 
+    @Autowired
+    private LikeJpaRepository likeJpaRepository;
+
     private Long memberId1;
     private Long memberId2;
     private Long spaceId;
+    private Long linkId;
 
     @BeforeEach
     void setUp() {
@@ -87,6 +97,49 @@ class LinkFacadeTest {
         //when
         Assertions.assertThatThrownBy(() -> linkFacade.createLink(spaceId, memberId2, request))
                 .isInstanceOf(UnauthorizedAccessException.class);
+    }
+
+    @Test
+    @DisplayName("좋아요에 성공한다.")
+    void createLike_request_Success() {
+        //given & when
+        Boolean isLiked = linkFacade.createLike(linkId, memberId1);
+
+        //then
+        assertThat(isLiked).isTrue();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 링크에 좋아요를 실패한다.")
+    void createLike_request_ThrowsDataNotFoundException() {
+        //given & when & then
+        Assertions.assertThatThrownBy(() -> linkFacade.createLike(999L, memberId1))
+                .isInstanceOf(DataNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("이미 좋아요한 링크에 좋아요를 실패한다.")
+    void createLike_request_ThrowsUnauthorizedAccessException() {
+        //given
+        linkFacade.createLike(linkId, memberId1);
+
+        //when & then
+        Assertions.assertThatThrownBy(() -> linkFacade.createLike(linkId, memberId1))
+                .isInstanceOf(UnauthorizedAccessException.class);
+    }
+
+    @Test
+    @DisplayName("좋아요 한 링크의 좋아요를 취소한다.")
+    void cancelLike_request_noContent() {
+        //given
+        linkFacade.createLike(linkId, memberId1);
+
+        //when
+        linkFacade.cancelLike(linkId, memberId1);
+
+        //then
+        Optional<Like> like = likeJpaRepository.findByLinkIdAndMemberId(linkId, memberId1);
+        assertThat(like).isEmpty();
     }
 
     private void setUpTestData() {
@@ -138,5 +191,16 @@ class LinkFacadeTest {
         );
 
         spaceId = spaceJpaRepository.save(space).getId();
+
+        //링크 생성 - link
+        Link link = Link.toLink(
+                space,
+                memberId1,
+                "보기 좋은 블로그 링크",
+                new Url("https://www.tistory.com"));
+
+        linkId = linkJpaRepository.save(link).getId();
     }
+
+
 }


### PR DESCRIPTION
- Like 테이블에 인서트하는 transaction과, 링크 내 좋아요 수 필드를 1 증가시키는 transaction을 나눴고 후자는 비동기 이벤트 처리로 구현하였습니다.

- 비동기 이벤트 처리 부분에 낙관적 락+Retry를 적용했습니다. 좋아요가 비핵심적인 기능인데 링크를 조회하는 기능에 영향을 받는 것은 데이터의 양이 많고 적고를 차치하고 좋은 형태는 아닐 것이라고 생각했습니다. 서비스 자체가 크지 않기에 비관적 락을 사용해도 어떠한 유저경험 저하를 느끼지 않을 수도 있겠지만, 좋아요라는 기능 자체가 비관적 락까지 가져갈 위치는 안된다고 생각해 낙관적 락을 이용을 하는게 좋을 것이라고 판단했습니다. 낙관적락의 롤백으로 인한 성능 저하도 생각해봤지만, 롤백으로 인한 성능 저하는 충돌이 빈번하게 일어날 때 걱정할 수 있다는 대전제가 있다는 것을 감안하면 충돌이 잦지 않다는 가정하에 비관적 락보다 사용 경험이 좋을 것이라고 생각했습니다.

- Retry는 라이브러리를 사용했으며 만일 세번을 시도하고 모두 실패하면, 이벤트 트랜잭션만 취소되고 좋아요 테이블 내 레코드 개수와 좋아요 수와 정합성은 깨지게 될 것 같습니다.