### PR TITLE
Feature/save link view history - 링크 접속 정보 저장 API 구현

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
@@ -149,6 +149,14 @@ public class LinkController {
     /**
      * 링크에 접속시 접속 정보를 저장하는 API
      */
+    @Operation(
+            summary = "링크 접속 정보 저장 API",
+            description = "[JWT 필요] 링크 접속 시 접속 정보를 저장하는 API입니다.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "링크 접속 이력 요청을 성공적으로 처리했습니다."),
+                    @ApiResponse(responseCode = "404", description = "스페이스 정보를 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "링크 정보를 찾을 수 없습니다.")
+            })
     @PostMapping(value = "/spaces/{spaceId}/links/{linkId}/view")
     public ResponseEntity<Void> addLinkViewHistory(
             @PathVariable Long spaceId,

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
@@ -9,8 +9,8 @@ import com.tenten.linkhub.domain.space.controller.dto.link.LinkUpdateApiResponse
 import com.tenten.linkhub.domain.space.controller.mapper.LinkApiMapper;
 import com.tenten.linkhub.domain.space.facade.LinkFacade;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
-import com.tenten.linkhub.global.response.ErrorResponse;
 import com.tenten.linkhub.domain.space.facade.dto.LinkUpdateFacadeRequest;
+import com.tenten.linkhub.global.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -145,4 +145,21 @@ public class LinkController {
 
         return ResponseEntity.noContent().build();
     }
+
+    /**
+     * 링크에 접속시 접속 정보를 저장하는 API
+     */
+    @PostMapping(value = "/spaces/{spaceId}/links/{linkId}/view")
+    public ResponseEntity<Void> addLinkViewHistory(
+            @PathVariable Long spaceId,
+            @PathVariable Long linkId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        linkFacade.addLinkViewHistory(spaceId, linkId, memberDetails.memberId());
+
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/exception/LinkViewHistoryException.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/exception/LinkViewHistoryException.java
@@ -1,0 +1,7 @@
+package com.tenten.linkhub.domain.space.exception;
+
+public class LinkViewHistoryException extends RuntimeException {
+    public LinkViewHistoryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
@@ -73,4 +73,9 @@ public class LinkFacade {
                 new LinkDecreaseLikeCountDto(linkId)
         );
     }
+
+    public void addLinkViewHistory(Long spaceId, Long linkId, Long memberId) {
+        spaceService.checkLinkViewHistory(spaceId, memberId);
+        linkService.addLinkViewHistory(spaceId, linkId, memberId);
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
@@ -10,6 +10,7 @@ import com.tenten.linkhub.domain.space.service.SpaceService;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkUpdateRequest;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -74,6 +75,7 @@ public class LinkFacade {
         );
     }
 
+    @Async
     public void addLinkViewHistory(Long spaceId, Long linkId, Long memberId) {
         spaceService.checkLinkViewHistory(spaceId, memberId);
         linkService.addLinkViewHistory(spaceId, linkId, memberId);

--- a/src/main/java/com/tenten/linkhub/domain/space/model/link/LinkViewHistory.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/link/LinkViewHistory.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.model.link;
 
+import com.tenten.linkhub.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -17,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "link_view_histories")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class LinkViewHistory {
+public class LinkViewHistory extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,4 +31,12 @@ public class LinkViewHistory {
     @JoinColumn(name = "link_id", nullable = false)
     private Link link;
 
+    private LinkViewHistory(Long memberId, Link link) {
+        this.memberId = memberId;
+        this.link = link;
+    }
+
+    public static LinkViewHistory toLinkViewHistory(Long memberId, Link link) {
+        return new LinkViewHistory(memberId, link);
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/Space.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/Space.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.model.space;
 
+import com.tenten.linkhub.domain.space.exception.LinkViewHistoryException;
 import com.tenten.linkhub.domain.space.model.category.Category;
 import com.tenten.linkhub.domain.space.model.space.dto.SpaceUpdateDto;
 import com.tenten.linkhub.domain.space.model.space.vo.SpaceImages;
@@ -15,13 +16,12 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
-import java.util.List;
-import java.util.Objects;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Objects;
 
 import static com.tenten.linkhub.global.util.CommonValidator.validateMaxSize;
 import static com.tenten.linkhub.global.util.CommonValidator.validateNotNull;
@@ -155,13 +155,13 @@ public class Space extends BaseEntity {
         }
     }
 
-    public void validateVisibilityAndMembership(Long memberId){
-        if (this.isVisible){
+    public void validateVisibilityAndMembership(Long memberId) {
+        if (this.isVisible) {
             return;
         }
 
         List<Long> spaceMemberIds = this.spaceMembers.getSpaceMemberIds();
-        if (!spaceMemberIds.contains(memberId)){
+        if (!spaceMemberIds.contains(memberId)) {
             throw new UnauthorizedAccessException("이 스페이스는 권한이 없으면 볼 수 없는 스페이스입니다.");
         }
     }
@@ -207,4 +207,12 @@ public class Space extends BaseEntity {
         return spaceImages.getAllSpaceImages();
     }
 
+
+    public void checkLinkViewHistoryEnabled(Long memberId) {
+        boolean isContainMember = spaceMembers.containMember(memberId);
+
+        if(!isContainMember || isReadMarkEnabled.equals(Boolean.FALSE)){
+            throw new LinkViewHistoryException("링크의 접속정보를 저장할 수 없습니다.");
+        }
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
@@ -1,20 +1,18 @@
 package com.tenten.linkhub.domain.space.model.space.vo;
 
-import com.tenten.linkhub.domain.space.model.space.Role;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import static com.tenten.linkhub.global.util.CommonValidator.validateNotNull;
 
@@ -62,11 +60,16 @@ public class SpaceMembers {
                 .filter(sm -> Objects.equals(sm.getMemberId(), memberId))
                 .findFirst();
 
-        if (spaceMember.isEmpty()){
+        if (spaceMember.isEmpty()) {
             return false;
         }
 
         return spaceMember.get().hasHigherRoleCanView();
     }
 
+    public boolean containMember(Long memberId) {
+        return spaceMemberList.
+                stream()
+                .anyMatch(m -> Objects.equals(m.getMemberId(), memberId));
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/DefaultLinkViewRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/DefaultLinkViewRepository.java
@@ -1,0 +1,31 @@
+package com.tenten.linkhub.domain.space.repository.linkview;
+
+import com.tenten.linkhub.domain.space.model.link.LinkViewHistory;
+import com.tenten.linkhub.domain.space.repository.linkview.query.LinkViewQueryRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class DefaultLinkViewRepository implements LinkViewRepository {
+
+    private final LinkViewQueryRepository linkViewQueryRepository;
+    private final LinkViewJpaRepository linkViewJpaRepository;
+
+    public DefaultLinkViewRepository(LinkViewQueryRepository linkViewQueryRepository,
+                                     LinkViewJpaRepository linkViewJpaRepository) {
+        this.linkViewQueryRepository = linkViewQueryRepository;
+        this.linkViewJpaRepository = linkViewJpaRepository;
+    }
+
+    @Override
+    public boolean existsLinkView(Long linkId, Long memberId) {
+        return linkViewQueryRepository.existsLinkViewHistory(linkId, memberId);
+    }
+
+    @Override
+    public LinkViewHistory save(LinkViewHistory linkViewHistory) {
+        return linkViewJpaRepository.save(linkViewHistory);
+    }
+
+}
+
+

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/LinkViewJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/LinkViewJpaRepository.java
@@ -1,0 +1,7 @@
+package com.tenten.linkhub.domain.space.repository.linkview;
+
+import com.tenten.linkhub.domain.space.model.link.LinkViewHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LinkViewJpaRepository extends JpaRepository<LinkViewHistory, Long> {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/LinkViewRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/LinkViewRepository.java
@@ -1,0 +1,11 @@
+package com.tenten.linkhub.domain.space.repository.linkview;
+
+import com.tenten.linkhub.domain.space.model.link.LinkViewHistory;
+
+public interface LinkViewRepository {
+
+    boolean existsLinkView(Long linkId, Long memberId);
+
+    LinkViewHistory save(LinkViewHistory linkViewHistory);
+
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/query/LinkViewQueryRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/query/LinkViewQueryRepository.java
@@ -1,0 +1,35 @@
+package com.tenten.linkhub.domain.space.repository.linkview.query;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import static com.tenten.linkhub.domain.space.model.link.QLinkViewHistory.linkViewHistory;
+
+@Repository
+public class LinkViewQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public LinkViewQueryRepository(JPAQueryFactory jpaQueryFactory) {
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    public boolean existsLinkViewHistory(Long linkId, Long memberId) {
+        Integer fetchOne = jpaQueryFactory
+                .selectOne()
+                .from(linkViewHistory)
+                .where(equalsMemberAndLink(memberId, linkId))
+                .fetchFirst();
+
+        return fetchOne != null;
+    }
+
+    private BooleanExpression equalsMemberAndLink(Long memberId, Long linkId) {
+        BooleanExpression memberCondition = linkViewHistory.memberId.eq(memberId);
+        BooleanExpression linkCondition = linkViewHistory.link.id.eq(linkId);
+
+        return memberCondition.and(linkCondition);
+    }
+
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultLinkService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultLinkService.java
@@ -1,13 +1,16 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.domain.space.exception.LinkViewHistoryException;
 import com.tenten.linkhub.domain.space.model.link.Color;
 import com.tenten.linkhub.domain.space.model.link.Like;
 import com.tenten.linkhub.domain.space.model.link.Link;
+import com.tenten.linkhub.domain.space.model.link.LinkViewHistory;
 import com.tenten.linkhub.domain.space.model.link.Tag;
 import com.tenten.linkhub.domain.space.model.link.vo.Url;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.repository.like.LikeRepository;
 import com.tenten.linkhub.domain.space.repository.link.LinkRepository;
+import com.tenten.linkhub.domain.space.repository.linkview.LinkViewRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceRepository;
 import com.tenten.linkhub.domain.space.repository.tag.TagRepository;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
@@ -27,12 +30,14 @@ public class DefaultLinkService implements LinkService {
     private final TagRepository tagRepository;
     private final SpaceRepository spaceRepository;
     private final LikeRepository likeRepository;
+    private final LinkViewRepository linkViewRepository;
 
-    public DefaultLinkService(LinkRepository linkRepository, TagRepository tagRepository, SpaceRepository spaceRepository, LikeRepository likeRepository) {
+    public DefaultLinkService(LinkRepository linkRepository, TagRepository tagRepository, SpaceRepository spaceRepository, LikeRepository likeRepository, LinkViewRepository linkViewRepository) {
         this.linkRepository = linkRepository;
         this.tagRepository = tagRepository;
         this.spaceRepository = spaceRepository;
         this.likeRepository = likeRepository;
+        this.linkViewRepository = linkViewRepository;
     }
 
     @Override
@@ -94,5 +99,17 @@ public class DefaultLinkService implements LinkService {
         Optional<Like> like = likeRepository.findByLinkIdAndMemberId(linkId, memberId);
 
         like.ifPresent(likeRepository::delete);
+    }
+
+    @Override
+    @Transactional
+    public void addLinkViewHistory(Long spaceId, Long linkId, Long memberId) {
+        if (linkViewRepository.existsLinkView(linkId, memberId)) {
+            throw new LinkViewHistoryException("이미 존재하는 접속 기록 데이터입니다.");
+        }
+
+        Link link = linkRepository.getById(linkId);
+        LinkViewHistory linkViewHistory = LinkViewHistory.toLinkViewHistory(memberId, link);
+        linkViewRepository.save(linkViewHistory);
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
@@ -1,6 +1,5 @@
 package com.tenten.linkhub.domain.space.service;
 
-import com.tenten.linkhub.domain.space.exception.LinkViewHistoryException;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
@@ -118,7 +117,7 @@ public class DefaultSpaceService implements SpaceService {
     }
 
     @Override
-    public void checkLinkViewHistory(Long memberId, Long spaceId) {
+    public void checkLinkViewHistory(Long spaceId, Long memberId) {
         Space space = spaceRepository.getSpaceJoinSpaceMemberById(spaceId);
 
         space.checkLinkViewHistoryEnabled(memberId);

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.domain.space.exception.LinkViewHistoryException;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
@@ -11,12 +12,12 @@ import com.tenten.linkhub.domain.space.repository.tag.dto.TagInfo;
 import com.tenten.linkhub.domain.space.service.dto.space.DeletedSpaceImageNames;
 import com.tenten.linkhub.domain.space.service.dto.space.MySpacesFindRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryResponses;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagGetResponse;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagGetResponses;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceUpdateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceWithSpaceImageAndSpaceMemberInfo;
-import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryResponses;
 import com.tenten.linkhub.domain.space.service.mapper.SpaceMapper;
 import com.tenten.linkhub.global.exception.UnauthorizedAccessException;
 import lombok.RequiredArgsConstructor;
@@ -114,6 +115,13 @@ public class DefaultSpaceService implements SpaceService {
                 .toList();
 
         return SpaceTagGetResponses.from(tagResponses);
+    }
+
+    @Override
+    public void checkLinkViewHistory(Long memberId, Long spaceId) {
+        Space space = spaceRepository.getSpaceJoinSpaceMemberById(spaceId);
+
+        space.checkLinkViewHistoryEnabled(memberId);
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/LinkService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/LinkService.java
@@ -12,4 +12,6 @@ public interface LinkService {
     Boolean createLike(Long linkId, Long memberId);
 
     void cancelLike(Long linkId, Long memberId);
+
+    void addLinkViewHistory(Long spaceId, Long linkId, Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
@@ -2,12 +2,12 @@ package com.tenten.linkhub.domain.space.service;
 
 import com.tenten.linkhub.domain.space.service.dto.space.DeletedSpaceImageNames;
 import com.tenten.linkhub.domain.space.service.dto.space.MySpacesFindRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryResponses;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagGetResponses;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceUpdateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceWithSpaceImageAndSpaceMemberInfo;
-import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryRequest;
-import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryResponses;
 
 public interface SpaceService {
 
@@ -26,4 +26,6 @@ public interface SpaceService {
     PublicSpacesFindByQueryResponses findMySpacesByQuery(MySpacesFindRequest mySpacesFindRequest);
 
     SpaceTagGetResponses getTagsBySpaceId(Long spaceId);
+
+    void checkLinkViewHistory(Long spaceId, Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/global/config/AsyncConfig.java
+++ b/src/main/java/com/tenten/linkhub/global/config/AsyncConfig.java
@@ -1,0 +1,24 @@
+package com.tenten.linkhub.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(8);
+        executor.setMaxPoolSize(8);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("linkhub-async");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/tenten/linkhub/global/config/AsyncConfig.java
+++ b/src/main/java/com/tenten/linkhub/global/config/AsyncConfig.java
@@ -1,7 +1,9 @@
 package com.tenten.linkhub.global.config;
 
-import org.springframework.context.annotation.Bean;
+import com.tenten.linkhub.global.exception.CustomAsyncExceptionHandler;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
@@ -9,9 +11,9 @@ import java.util.concurrent.Executor;
 
 @Configuration
 @EnableAsync
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
 
-    @Bean
+    @Override
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(8);
@@ -20,5 +22,10 @@ public class AsyncConfig {
         executor.setThreadNamePrefix("linkhub-async");
         executor.initialize();
         return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new CustomAsyncExceptionHandler();
     }
 }

--- a/src/main/java/com/tenten/linkhub/global/exception/CustomAsyncExceptionHandler.java
+++ b/src/main/java/com/tenten/linkhub/global/exception/CustomAsyncExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.tenten.linkhub.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+public class CustomAsyncExceptionHandler implements AsyncUncaughtExceptionHandler {
+
+    @Override
+    public void handleUncaughtException(Throwable throwable, Method method, Object... obj) {
+        log.warn("Async Exception: ", throwable.fillInStackTrace());
+    }
+
+}

--- a/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
+++ b/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.global.exception;
 
+import com.tenten.linkhub.domain.space.exception.LinkViewHistoryException;
 import com.tenten.linkhub.global.response.ErrorResponse;
 import com.tenten.linkhub.global.response.ErrorWithDetailCodeResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -66,8 +67,8 @@ public class GlobalApiExceptionHandler {
     }
 
     @ExceptionHandler(DataDuplicateException.class)
-    public ResponseEntity<ErrorWithDetailCodeResponse> handleDataDuplicateException(HttpServletRequest request,
-                                                                                    DataDuplicateException e) {
+    public ResponseEntity<ErrorWithDetailCodeResponse> handleDataDuplspace_imagesicateException(HttpServletRequest request,
+                                                                                                DataDuplicateException e) {
         ErrorWithDetailCodeResponse errorResponse = ErrorWithDetailCodeResponse.of(
                 e.getErrorCode(),
                 request.getRequestURI()
@@ -76,6 +77,14 @@ public class GlobalApiExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(errorResponse);
+    }
+
+    @ExceptionHandler(LinkViewHistoryException.class)
+    public ResponseEntity<Void> handleLinkViewHistoryException(HttpServletRequest request,
+                                                               LinkViewHistoryException e) {
+        return ResponseEntity
+                .ok()
+                .body(null);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
+++ b/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
@@ -66,8 +66,8 @@ public class GlobalApiExceptionHandler {
     }
 
     @ExceptionHandler(DataDuplicateException.class)
-    public ResponseEntity<ErrorWithDetailCodeResponse> handleDataDuplspace_imagesicateException(HttpServletRequest request,
-                                                                                                DataDuplicateException e) {
+    public ResponseEntity<ErrorWithDetailCodeResponse> handleDataDuplicateException(HttpServletRequest request,
+                                                                                    DataDuplicateException e) {
         ErrorWithDetailCodeResponse errorResponse = ErrorWithDetailCodeResponse.of(
                 e.getErrorCode(),
                 request.getRequestURI()

--- a/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
+++ b/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.tenten.linkhub.global.exception;
 
-import com.tenten.linkhub.domain.space.exception.LinkViewHistoryException;
 import com.tenten.linkhub.global.response.ErrorResponse;
 import com.tenten.linkhub.global.response.ErrorWithDetailCodeResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -77,14 +76,6 @@ public class GlobalApiExceptionHandler {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(errorResponse);
-    }
-
-    @ExceptionHandler(LinkViewHistoryException.class)
-    public ResponseEntity<Void> handleLinkViewHistoryException(HttpServletRequest request,
-                                                               LinkViewHistoryException e) {
-        return ResponseEntity
-                .ok()
-                .body(null);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
@@ -5,6 +5,7 @@ import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
 import com.tenten.linkhub.domain.member.model.Provider;
 import com.tenten.linkhub.domain.member.repository.member.MemberJpaRepository;
+import com.tenten.linkhub.domain.space.exception.LinkViewHistoryException;
 import com.tenten.linkhub.domain.space.model.category.Category;
 import com.tenten.linkhub.domain.space.model.link.Color;
 import com.tenten.linkhub.domain.space.model.link.Link;
@@ -17,6 +18,7 @@ import com.tenten.linkhub.domain.space.repository.link.LinkJpaRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkUpdateRequest;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -100,6 +102,17 @@ class DefaultLinkServiceTest {
         assertThat(savedLink.getTags().get(0).getName()).isEqualTo("바꾼 태그");
     }
 
+    @Test
+    @DisplayName("이미 링크 접속 이력이 있을 경우 데이터를 저장할 수 없다.")
+    void addLinkViewHistory_MemberIdAndSpaceIdAndLinkId_ThrowsException() {
+        //given
+        linkService.addLinkViewHistory(spaceId, linkId, memberId1);
+
+        //when & then
+        Assertions.assertThatThrownBy(() -> linkService.addLinkViewHistory(spaceId, linkId, memberId1))
+                .isInstanceOf(LinkViewHistoryException.class);
+    }
+
     private void setUpTestData() {
         Member member1 = new Member(
                 "123456",
@@ -135,4 +148,6 @@ class DefaultLinkServiceTest {
         Link link = Link.toLink(space, memberId1, "링크의 제목", new Url("https://www.naver.com"));
         linkId = linkJpaRepository.save(link).getId();
     }
+
 }
+

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
@@ -5,6 +5,7 @@ import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
 import com.tenten.linkhub.domain.member.model.Provider;
 import com.tenten.linkhub.domain.member.repository.member.MemberJpaRepository;
+import com.tenten.linkhub.domain.space.exception.LinkViewHistoryException;
 import com.tenten.linkhub.domain.space.facade.LinkFacade;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.model.category.Category;
@@ -15,11 +16,12 @@ import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
 import com.tenten.linkhub.domain.space.service.dto.space.MySpacesFindRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryResponses;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagGetResponse;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagGetResponses;
-import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryResponse;
-import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryResponses;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -53,6 +55,7 @@ class DefaultSpaceServiceTest {
 
     private Long setUpMemberId;
     private Long spaceId1;
+    private Long spaceId3;
 
     @BeforeEach
     void setUp() {
@@ -158,6 +161,22 @@ class DefaultSpaceServiceTest {
         assertThat(response.tags()).containsExactlyInAnyOrderElementsOf(List.of(new SpaceTagGetResponse("태그1", "gray"), new SpaceTagGetResponse("태그2", "red")));
     }
 
+    @Test
+    @DisplayName("스페이스에서 읽음 처리 기능을 활성화하지 않았다면 이력을 저장할 수 없다.")
+    void checkLinkViewHistory_MemberIdAndSpaceId_ThrowsException() {
+        //when & then
+        Assertions.assertThatThrownBy(() -> spaceService.checkLinkViewHistory(spaceId1, setUpMemberId))
+                .isInstanceOf(LinkViewHistoryException.class);
+    }
+
+    @Test
+    @DisplayName("스페이스의 멤버가 아니라면 읽음 처리 기능이 활성화 되어있더라도 이력을 저장할 수 없다.")
+    void checkLinkViewHistory_MemberIdAndSpaceId2_ThrowsException() {
+        //when & then
+        Assertions.assertThatThrownBy(() -> spaceService.checkLinkViewHistory(spaceId3, setUpMemberId))
+                .isInstanceOf(LinkViewHistoryException.class);
+    }
+
     private void setupData() {
         Member member = new Member(
                 "testSocialId",
@@ -183,7 +202,7 @@ class DefaultSpaceServiceTest {
                 true,
                 true,
                 true,
-                true
+                false
         );
 
         Space space2 = new Space(
@@ -217,6 +236,7 @@ class DefaultSpaceServiceTest {
         spaceJpaRepository.save(space3);
 
         spaceId1 = space1.getId();
+        spaceId3 = space3.getId();
     }
 
 }


### PR DESCRIPTION
## 🔗 이슈
#87 

## 📒 구현 내용 📒

### 링크 접속 정보 저장 API 구현
- 접속 정보 저장 관련 메소드가 모두 void이기에 별도의 asyncService 클래스를 개발하지 않고 진행했습니다.
- @ ControllerAdvice로는 동기적 예외만 캐치할 수 있어 별도의 CustomAsyncExceptionHandler를 만들었습니다.
- asyncExceptionHandler에서는 예외를 캐치하여 ResponseEntity response를 내려주는 것이 권장되지 않아 성공적으로 저장하건 , 스페이스가 읽음 처리를 허용하지 않아 저장하지 않건 204를 반환하는 구조로 진행했습니다. (exceptionHandler에서 로그 남기도록 함)