### PR TITLE
Fix/favorite/yyw. -  스페이스 즐겨찾기 관련 API 수정

### DIFF
--- a/src/main/java/com/tenten/linkhub/LinkHubApplication.java
+++ b/src/main/java/com/tenten/linkhub/LinkHubApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
 
-@EnableAsync
 @SpringBootApplication
 public class LinkHubApplication {
 

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
@@ -3,8 +3,8 @@ package com.tenten.linkhub.domain.space.facade;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.dto.LinkUpdateFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.mapper.LinkFacadeMapper;
-import com.tenten.linkhub.domain.space.handler.dto.LinkDecreaseLikeCountDto;
-import com.tenten.linkhub.domain.space.handler.dto.LinkIncreaseLikeCountDto;
+import com.tenten.linkhub.domain.space.handler.dto.LinkDecreaseLikeCountEvent;
+import com.tenten.linkhub.domain.space.handler.dto.LinkIncreaseLikeCountEvent;
 import com.tenten.linkhub.domain.space.service.LinkService;
 import com.tenten.linkhub.domain.space.service.SpaceService;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
@@ -60,7 +60,7 @@ public class LinkFacade {
         Boolean isLiked = linkService.createLike(linkId, memberId);
 
         eventPublisher.publishEvent(
-                new LinkIncreaseLikeCountDto(linkId)
+                new LinkIncreaseLikeCountEvent(linkId)
         );
 
         return isLiked;
@@ -70,7 +70,7 @@ public class LinkFacade {
         linkService.cancelLike(linkId, memberId);
 
         eventPublisher.publishEvent(
-                new LinkDecreaseLikeCountDto(linkId)
+                new LinkDecreaseLikeCountEvent(linkId)
         );
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/SpaceFacade.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/SpaceFacade.java
@@ -7,8 +7,8 @@ import com.tenten.linkhub.domain.space.facade.dto.SpaceDetailGetByIdFacadeReques
 import com.tenten.linkhub.domain.space.facade.dto.SpaceDetailGetByIdFacadeResponse;
 import com.tenten.linkhub.domain.space.facade.dto.SpaceUpdateFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.mapper.SpaceFacadeMapper;
-import com.tenten.linkhub.domain.space.handler.dto.SpaceImagesDeleteDto;
-import com.tenten.linkhub.domain.space.handler.dto.SpaceIncreaseViewCountDto;
+import com.tenten.linkhub.domain.space.handler.dto.SpaceImagesDeleteEvent;
+import com.tenten.linkhub.domain.space.handler.dto.SpaceIncreaseViewCountEvent;
 import com.tenten.linkhub.domain.space.service.SpaceImageUploader;
 import com.tenten.linkhub.domain.space.service.SpaceService;
 import com.tenten.linkhub.domain.space.service.dto.space.DeletedSpaceImageNames;
@@ -66,7 +66,7 @@ public class SpaceFacade {
         DeletedSpaceImageNames deletedSpaceImageNames = spaceService.deleteSpaceById(spaceId, memberId);
 
         eventPublisher.publishEvent(
-                new SpaceImagesDeleteDto(deletedSpaceImageNames.fileNames())
+                new SpaceImagesDeleteEvent(deletedSpaceImageNames.fileNames())
         );
     }
 
@@ -79,7 +79,7 @@ public class SpaceFacade {
     private List<Long> increaseSpaceViewCountAndSetSpaceViews(List<Long> spaceViews, Long spaceId) {
         if (spaceViews.isEmpty()) {
             eventPublisher.publishEvent(
-                    new SpaceIncreaseViewCountDto(spaceId)
+                    new SpaceIncreaseViewCountEvent(spaceId)
             );
 
             spaceViews.add(spaceId);
@@ -88,7 +88,7 @@ public class SpaceFacade {
 
         if (!spaceViews.contains(spaceId)) {
             eventPublisher.publishEvent(
-                    new SpaceIncreaseViewCountDto(spaceId)
+                    new SpaceIncreaseViewCountEvent(spaceId)
             );
 
             spaceViews.add(spaceId);

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/LinkEventHandler.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/LinkEventHandler.java
@@ -1,7 +1,7 @@
 package com.tenten.linkhub.domain.space.handler;
 
-import com.tenten.linkhub.domain.space.handler.dto.LinkDecreaseLikeCountDto;
-import com.tenten.linkhub.domain.space.handler.dto.LinkIncreaseLikeCountDto;
+import com.tenten.linkhub.domain.space.handler.dto.LinkDecreaseLikeCountEvent;
+import com.tenten.linkhub.domain.space.handler.dto.LinkIncreaseLikeCountEvent;
 import com.tenten.linkhub.domain.space.model.link.Link;
 import com.tenten.linkhub.domain.space.repository.link.LinkRepository;
 import jakarta.persistence.OptimisticLockException;
@@ -30,8 +30,8 @@ public class LinkEventHandler {
             maxAttempts = 3,
             backoff = @Backoff(delay = 100)
     )
-    public void increaseLikeCount(LinkIncreaseLikeCountDto linkIncreaseLikeCountDto) {
-        linkRepository.findById(linkIncreaseLikeCountDto.linkId())
+    public void increaseLikeCount(LinkIncreaseLikeCountEvent linkIncreaseLikeCountEvent) {
+        linkRepository.findById(linkIncreaseLikeCountEvent.linkId())
                 .ifPresent(Link::increaseLikeCount);
     }
 
@@ -43,8 +43,8 @@ public class LinkEventHandler {
             maxAttempts = 3,
             backoff = @Backoff(delay = 100)
     )
-    public void decreaseLikeCount(LinkDecreaseLikeCountDto linkDecreaseLikeCountDto) {
-        linkRepository.findById(linkDecreaseLikeCountDto.linkId())
+    public void decreaseLikeCount(LinkDecreaseLikeCountEvent linkDecreaseLikeCountEvent) {
+        linkRepository.findById(linkDecreaseLikeCountEvent.linkId())
                 .ifPresent(Link::decreaseLikeCount);
     }
 

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/SpaceEventHandler.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/SpaceEventHandler.java
@@ -1,7 +1,8 @@
 package com.tenten.linkhub.domain.space.handler;
 
-import com.tenten.linkhub.domain.space.handler.dto.SpaceImagesDeleteDto;
-import com.tenten.linkhub.domain.space.handler.dto.SpaceIncreaseViewCountDto;
+import com.tenten.linkhub.domain.space.handler.dto.SpaceImagesDeleteEvent;
+import com.tenten.linkhub.domain.space.handler.dto.SpaceIncreaseFavoriteCountEvent;
+import com.tenten.linkhub.domain.space.handler.dto.SpaceIncreaseViewCountEvent;
 import com.tenten.linkhub.domain.space.repository.space.SpaceRepository;
 import com.tenten.linkhub.global.aws.s3.S3Uploader;
 import org.springframework.context.event.EventListener;
@@ -26,15 +27,22 @@ public class SpaceEventHandler {
     @Async
     @EventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void increaseSpaceViewCount(SpaceIncreaseViewCountDto increaseViewCountDto){
-        spaceRepository.getById(increaseViewCountDto.spaceId())
+    public void increaseSpaceViewCount(SpaceIncreaseViewCountEvent event){
+        spaceRepository.getById(event.spaceId())
                 .increaseViewCount();
     }
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    public void deleteImageFiles(SpaceImagesDeleteDto imagesDeleteDto) {
-        s3Uploader.deleteImages(imagesDeleteDto.spaceImageNames());
+    public void deleteImageFiles(SpaceImagesDeleteEvent event) {
+        s3Uploader.deleteImages(event.spaceImageNames());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void increaseFavoriteCount (SpaceIncreaseFavoriteCountEvent event) {
+        spaceRepository.increaseFavoriteCount(event.spaceId());
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/SpaceEventHandler.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/SpaceEventHandler.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.handler;
 
+import com.tenten.linkhub.domain.space.handler.dto.SpaceDecreaseFavoriteCountEvent;
 import com.tenten.linkhub.domain.space.handler.dto.SpaceImagesDeleteEvent;
 import com.tenten.linkhub.domain.space.handler.dto.SpaceIncreaseFavoriteCountEvent;
 import com.tenten.linkhub.domain.space.handler.dto.SpaceIncreaseViewCountEvent;
@@ -43,6 +44,13 @@ public class SpaceEventHandler {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void increaseFavoriteCount (SpaceIncreaseFavoriteCountEvent event) {
         spaceRepository.increaseFavoriteCount(event.spaceId());
+    }
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void decreaseFavoriteCount (SpaceDecreaseFavoriteCountEvent event) {
+        spaceRepository.decreaseFavoriteCount(event.spaceId());
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/dto/LinkDecreaseLikeCountDto.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/dto/LinkDecreaseLikeCountDto.java
@@ -1,4 +1,0 @@
-package com.tenten.linkhub.domain.space.handler.dto;
-
-public record LinkDecreaseLikeCountDto(Long linkId) {
-}

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/dto/LinkDecreaseLikeCountEvent.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/dto/LinkDecreaseLikeCountEvent.java
@@ -1,4 +1,4 @@
 package com.tenten.linkhub.domain.space.handler.dto;
 
-public record LinkIncreaseLikeCountDto(Long linkId) {
+public record LinkDecreaseLikeCountEvent(Long linkId) {
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/dto/LinkIncreaseLikeCountEvent.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/dto/LinkIncreaseLikeCountEvent.java
@@ -1,4 +1,4 @@
 package com.tenten.linkhub.domain.space.handler.dto;
 
-public record SpaceIncreaseViewCountDto(Long spaceId) {
+public record LinkIncreaseLikeCountEvent(Long linkId) {
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/dto/SpaceDecreaseFavoriteCountEvent.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/dto/SpaceDecreaseFavoriteCountEvent.java
@@ -1,0 +1,4 @@
+package com.tenten.linkhub.domain.space.handler.dto;
+
+public record SpaceDecreaseFavoriteCountEvent(Long spaceId) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/dto/SpaceImagesDeleteEvent.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/dto/SpaceImagesDeleteEvent.java
@@ -2,6 +2,6 @@ package com.tenten.linkhub.domain.space.handler.dto;
 
 import java.util.List;
 
-public record SpaceImagesDeleteDto(List<String> spaceImageNames) {
+public record SpaceImagesDeleteEvent(List<String> spaceImageNames) {
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/dto/SpaceIncreaseFavoriteCountEvent.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/dto/SpaceIncreaseFavoriteCountEvent.java
@@ -1,0 +1,4 @@
+package com.tenten.linkhub.domain.space.handler.dto;
+
+public record SpaceIncreaseFavoriteCountEvent(Long spaceId) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/handler/dto/SpaceIncreaseViewCountEvent.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/handler/dto/SpaceIncreaseViewCountEvent.java
@@ -1,0 +1,4 @@
+package com.tenten.linkhub.domain.space.handler.dto;
+
+public record SpaceIncreaseViewCountEvent(Long spaceId) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/Favorite.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/Favorite.java
@@ -36,14 +36,15 @@ public class Favorite extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "space_id", nullable = false)
-    private Long spaceId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "space_id", referencedColumnName = "id", nullable = false)
+    private Space space;
 
     @Column(name = "member_id", nullable = false)
     private Long memberId;
 
-    public Favorite(Long spaceId, Long memberId) {
-        this.spaceId = spaceId;
+    public Favorite(Space space, Long memberId) {
+        this.space = space;
         this.memberId = memberId;
     }
 

--- a/src/main/java/com/tenten/linkhub/domain/space/service/FavoriteService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/FavoriteService.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.domain.space.handler.dto.SpaceIncreaseFavoriteCountEvent;
 import com.tenten.linkhub.domain.space.model.space.Favorite;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.repository.favorite.FavoriteRepository;
@@ -9,6 +10,7 @@ import com.tenten.linkhub.domain.space.service.mapper.FavoriteMapper;
 import com.tenten.linkhub.global.exception.DataDuplicateException;
 import com.tenten.linkhub.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +21,7 @@ public class FavoriteService {
     private final FavoriteRepository favoriteRepository;
     private final SpaceRepository spaceRepository;
     private final FavoriteMapper mapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public SpaceRegisterInFavoriteResponse createFavorite(Long spaceId, Long memberId) {
@@ -30,7 +33,7 @@ public class FavoriteService {
         Favorite favorite = mapper.toFavorite(space, memberId);
         Favorite savedFavorite = favoriteRepository.save(favorite);
 
-        spaceRepository.increaseFavoriteCount(spaceId);
+        eventPublisher.publishEvent(new SpaceIncreaseFavoriteCountEvent(spaceId));
 
         return SpaceRegisterInFavoriteResponse.of(
                 savedFavorite.getId(),

--- a/src/main/java/com/tenten/linkhub/domain/space/service/FavoriteService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/FavoriteService.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.domain.space.handler.dto.SpaceDecreaseFavoriteCountEvent;
 import com.tenten.linkhub.domain.space.handler.dto.SpaceIncreaseFavoriteCountEvent;
 import com.tenten.linkhub.domain.space.model.space.Favorite;
 import com.tenten.linkhub.domain.space.model.space.Space;
@@ -47,7 +48,7 @@ public class FavoriteService {
 
         Long deletedFavoriteId = favoriteRepository.deleteById(favorite.getId());
 
-        spaceRepository.decreaseFavoriteCount(spaceId);
+        eventPublisher.publishEvent(new SpaceDecreaseFavoriteCountEvent(spaceId));
 
         return deletedFavoriteId;
     }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/FavoriteService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/FavoriteService.java
@@ -27,7 +27,7 @@ public class FavoriteService {
 
         checkDuplicateFavorite(spaceId, memberId);
 
-        Favorite favorite = mapper.toFavorite(spaceId, memberId);
+        Favorite favorite = mapper.toFavorite(space, memberId);
         Favorite savedFavorite = favoriteRepository.save(favorite);
 
         spaceRepository.increaseFavoriteCount(spaceId);

--- a/src/main/java/com/tenten/linkhub/domain/space/service/mapper/FavoriteMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/mapper/FavoriteMapper.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class FavoriteMapper {
 
-    public Favorite toFavorite(Long spaceId, Long memberId) {
-        return new Favorite(spaceId, memberId);
+    public Favorite toFavorite(Space space, Long memberId) {
+        return new Favorite(space, memberId);
     }
 }

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/SpaceFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/SpaceFacadeTest.java
@@ -290,7 +290,7 @@ class SpaceFacadeTest {
         Space savedSpace = spaceJpaRepository.save(space);
         setUpSpaceId = savedSpace.getId();
 
-        Favorite favorite = new Favorite(setUpSpaceId, setUpMemberId);
+        Favorite favorite = new Favorite(savedSpace, setUpMemberId);
         favoriteJpaRepository.save(favorite);
     }
 

--- a/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
@@ -15,7 +15,6 @@ import com.tenten.linkhub.domain.space.repository.favorite.FavoriteJpaRepository
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
 import com.tenten.linkhub.domain.space.service.dto.favorite.SpaceRegisterInFavoriteResponse;
 import com.tenten.linkhub.global.exception.DataNotFoundException;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -23,8 +22,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -57,16 +54,16 @@ class FavoriteServiceTest {
     }
 
     @AfterEach
-    void tearDown(){
+    void tearDown() {
         favoriteJpaRepository.deleteAll();
     }
 
     @Test
     @DisplayName("유저는 스페이스를 즐겨찾기에 등록할 수 있다.")
-    @Transactional
-    void createFavorite() {
+    void createFavorite() throws InterruptedException {
         //when
         SpaceRegisterInFavoriteResponse response = favoriteService.createFavorite(setUpSpaceId, setUpMemberId);
+        Thread.sleep(1000);
 
         //then
         Favorite savedFavorite = favoriteJpaRepository.findById(response.favoriteId()).get();
@@ -98,6 +95,7 @@ class FavoriteServiceTest {
             });
         }
         latch.await();
+        Thread.sleep(1000);
 
         //then
         Space space = spaceJpaRepository.findById(setUpSpaceId).get();
@@ -106,10 +104,10 @@ class FavoriteServiceTest {
 
     @Test
     @DisplayName("유저는 스페이스 즐겨찾기를 취소할 수 있다.")
-    @Transactional
-    void cancelFavoriteSpace() {
+    void cancelFavoriteSpace() throws InterruptedException {
         //given
         favoriteService.createFavorite(setUpSpaceId, setUpMemberId);
+        Thread.sleep(1000);
 
         //when
         Long deletedFavoriteId = favoriteService.cancelFavoriteSpace(setUpSpaceId, setUpMemberId);
@@ -153,7 +151,7 @@ class FavoriteServiceTest {
                 true
         );
 
-        spaceJpaRepository.save(space);
         setUpSpaceId = spaceJpaRepository.save(space).getId();
     }
+
 }

--- a/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
@@ -63,7 +63,7 @@ class FavoriteServiceTest {
     void createFavorite() throws InterruptedException {
         //when
         SpaceRegisterInFavoriteResponse response = favoriteService.createFavorite(setUpSpaceId, setUpMemberId);
-        Thread.sleep(1000);
+        Thread.sleep(100);
 
         //then
         Favorite savedFavorite = favoriteJpaRepository.findById(response.favoriteId()).get();
@@ -107,10 +107,11 @@ class FavoriteServiceTest {
     void cancelFavoriteSpace() throws InterruptedException {
         //given
         favoriteService.createFavorite(setUpSpaceId, setUpMemberId);
-        Thread.sleep(1000);
+        Thread.sleep(100);
 
         //when
         Long deletedFavoriteId = favoriteService.cancelFavoriteSpace(setUpSpaceId, setUpMemberId);
+        Thread.sleep(100);
 
         //then
         Space space = spaceJpaRepository.findById(setUpSpaceId).get();


### PR DESCRIPTION
## 작업한 일
- Favorite내의 Space 간점참조로 변경한거 다시 객체 참조로 변경.
- 즐겨찾기 추가 및 취소 시 Space의 favoriteCount 증가, 감소 로직 이벤트로 분리 후 비동기 처리 방식으로 변경.
- 즐겨찾기 추가 및 취소 테스트 코드 변경.