### PR TITLE
Feature/delete link - 링크 삭제 API 구현 & Link Entity 수정

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
@@ -173,6 +173,15 @@ public class LinkController {
     /**
      * 링크 삭제 API
      */
+    @Operation(
+            summary = "링크 삭제 API",
+            description = "[JWT 필요] 스페이스 내에서 링크를 삭제하는 API 입니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "링크가 성공적으로 삭제된 경우"),
+                    @ApiResponse(responseCode = "404", description = "링크 삭제 권한이 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "요청한 spaceId에 해당하는 스페이스를 찾을 수 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "요청한 linkId에 해당하는 스페이스를 찾을 수 없습니다.")
+            })
     @DeleteMapping(value = "/spaces/{spaceId}/links/{linkId}")
     public ResponseEntity<Void> deleteLink(
             @PathVariable Long spaceId,

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
@@ -170,4 +170,20 @@ public class LinkController {
                 .build();
     }
 
+    /**
+     * 링크 삭제 API
+     */
+    @DeleteMapping(value = "/spaces/{spaceId}/links/{linkId}")
+    public ResponseEntity<Void> deleteLink(
+            @PathVariable Long spaceId,
+            @PathVariable Long linkId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        linkFacade.deleteLink(spaceId, linkId, memberDetails.memberId());
+
+        return ResponseEntity
+                .noContent()
+                .build();
+    }
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/facade/LinkFacade.java
@@ -80,4 +80,9 @@ public class LinkFacade {
         spaceService.checkLinkViewHistory(spaceId, memberId);
         linkService.addLinkViewHistory(spaceId, linkId, memberId);
     }
+
+    public void deleteLink(Long spaceId, Long linkId, Long memberId) {
+        spaceService.checkMemberEditLink(memberId, spaceId);
+        linkService.deleteLink(linkId);
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/link/Link.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/link/Link.java
@@ -40,7 +40,7 @@ public class Link extends BaseEntity {
     @JoinColumn(name = "space_id", nullable = false)
     private Space space;
 
-    @OneToMany(mappedBy = "link", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    @OneToMany(mappedBy = "link", cascade = CascadeType.PERSIST)
     private List<Tag> tags = new ArrayList<>();
 
     @Column(nullable = false)
@@ -51,9 +51,6 @@ public class Link extends BaseEntity {
 
     @Embedded
     private Url url;
-
-    @Column(nullable = false)
-    private Long viewCount;
 
     @Column(nullable = false)
     private Long likeCount;
@@ -91,7 +88,6 @@ public class Link extends BaseEntity {
         this.title = title;
         this.url = url;
         this.likeCount = 0L;
-        this.viewCount = 0L;
     }
 
     public void updateLink(Url url, String title, Optional<Tag> tag) {
@@ -115,11 +111,17 @@ public class Link extends BaseEntity {
         this.tags.forEach(Tag::deleteTag);
         this.tags.clear();
     }
+
     public void increaseLikeCount() {
         likeCount++;
     }
 
     public void decreaseLikeCount() {
         likeCount--;
+    }
+
+    public void deleteLink() {
+        this.isDeleted = true;
+
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/DefaultLinkRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/DefaultLinkRepository.java
@@ -30,4 +30,5 @@ public class DefaultLinkRepository implements LinkRepository {
     public Optional<Link> findById(Long linkId) {
         return linkJpaRepository.findById(linkId);
     }
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkRepository.java
@@ -10,6 +10,5 @@ public interface LinkRepository {
 
     Link getById(Long linkId);
 
-
     Optional<Link> findById(Long linkId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/DefaultLinkViewRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/DefaultLinkViewRepository.java
@@ -26,6 +26,11 @@ public class DefaultLinkViewRepository implements LinkViewRepository {
         return linkViewJpaRepository.save(linkViewHistory);
     }
 
+    @Override
+    public void deleteLinkViewHistory(Long linkId) {
+        linkViewJpaRepository.deleteByLinkId(linkId);
+    }
+
 }
 
 

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/LinkViewJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/LinkViewJpaRepository.java
@@ -4,4 +4,5 @@ import com.tenten.linkhub.domain.space.model.link.LinkViewHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LinkViewJpaRepository extends JpaRepository<LinkViewHistory, Long> {
+    void deleteByLinkId(Long linkId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/LinkViewRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/linkview/LinkViewRepository.java
@@ -8,4 +8,5 @@ public interface LinkViewRepository {
 
     LinkViewHistory save(LinkViewHistory linkViewHistory);
 
+    void deleteLinkViewHistory(Long linkId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultLinkService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultLinkService.java
@@ -112,4 +112,13 @@ public class DefaultLinkService implements LinkService {
         LinkViewHistory linkViewHistory = LinkViewHistory.toLinkViewHistory(memberId, link);
         linkViewRepository.save(linkViewHistory);
     }
+
+    @Override
+    @Transactional
+    public void deleteLink(Long linkId) {
+        Link link = linkRepository.getById(linkId);
+
+        link.deleteLink();
+        linkViewRepository.deleteLinkViewHistory(linkId);
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/LinkService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/LinkService.java
@@ -14,4 +14,6 @@ public interface LinkService {
     void cancelLike(Long linkId, Long memberId);
 
     void addLinkViewHistory(Long spaceId, Long linkId, Long memberId);
+
+    void deleteLink(Long linkId);
 }

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
@@ -184,6 +184,14 @@ class LinkFacadeTest {
         assertThat(like).isEmpty();
     }
 
+    @Test
+    @DisplayName("사용자는 CAN_EDIT이나 OWNER 권한이 아닌 경우 링크를 삭제할 수 없다.")
+    void deleteLink_request_ThrowsUnauthorizedAccessException() {
+        //when & then
+        Assertions.assertThatThrownBy(() -> linkFacade.deleteLink(spaceId, linkId, memberId2))
+                .isInstanceOf(UnauthorizedAccessException.class);
+    }
+
     private void setUpTestData() {
         Member member1 = new Member(
                 "123456",

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
@@ -113,6 +113,17 @@ class DefaultLinkServiceTest {
                 .isInstanceOf(LinkViewHistoryException.class);
     }
 
+    @Test
+    @DisplayName("사용자는 링크를 삭제할 수 있다.")
+    void deleteLink_LinkId_Success() {
+        //when
+        linkService.deleteLink(linkId);
+
+        //then
+        int linkCount = (int) linkJpaRepository.findById(linkId).stream().count();
+        assertThat(linkCount).isEqualTo(0);
+    }
+
     private void setUpTestData() {
         Member member1 = new Member(
                 "123456",


### PR DESCRIPTION
## 🔗 이슈
#86 

## 📒 구현 내용 📒

### 링크 삭제 API
- 링크 삭제 API 구현했습니다.
- 링크 삭제 시 `링크 softDelete` + `접속이력 hardDelete`로 구현하였고 링크의 태그는 삭제되지 않도록 구현했습니다.
- 링크 삭제 테스트 코드 작성
- Swagger 코드 추가

### Link Entity 수정
- viewCount 필드 삭제
- orphanRemoval 삭제