### PR TITLE
Hotfix/find spaces by query/yyw  -  스페이스 검색 API들 데이터 중복 이슈 해결

### DIFF
--- a/src/main/java/com/tenten/linkhub/LinkHubApplication.java
+++ b/src/main/java/com/tenten/linkhub/LinkHubApplication.java
@@ -2,7 +2,6 @@ package com.tenten.linkhub;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 public class LinkHubApplication {

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceImages.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceImages.java
@@ -24,13 +24,13 @@ public class SpaceImages {
     private List<SpaceImage> spaceImageList = new ArrayList<>();
 
     public void addSpaceImage(SpaceImage spaceImage) {
-        validateNotNull(spaceImage, "spaceImage");
+        validateNotNull(spaceImage, "spaceImages");
 
         this.spaceImageList.add(spaceImage);
     }
 
     public void changeSpaceImage(SpaceImage spaceImage) {
-        validateNotNull(spaceImage, "spaceImage");
+        validateNotNull(spaceImage, "spaceImages");
 
         List<SpaceImage> imageList = getSpaceImageList();
 

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
@@ -26,7 +26,7 @@ public class SpaceMembers {
     private List<SpaceMember> spaceMemberList = new ArrayList<>();
 
     public void addSpaceMember(SpaceMember spaceMember) {
-        validateNotNull(spaceMember, "spaceImage");
+        validateNotNull(spaceMember, "spaceImages");
 
         this.spaceMemberList.add(spaceMember);
     }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/common/dto/SpaceAndOwnerNickName.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/common/dto/SpaceAndOwnerNickName.java
@@ -7,11 +7,9 @@ public record SpaceAndOwnerNickName(
         Space space,
         String ownerNickName
 ) {
-
     @QueryProjection
     public SpaceAndOwnerNickName(Space space, String ownerNickName) {
         this.space = space;
         this.ownerNickName = ownerNickName;
     }
-
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/common/dto/SpaceAndSpaceImageOwnerNickName.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/common/dto/SpaceAndSpaceImageOwnerNickName.java
@@ -1,0 +1,13 @@
+package com.tenten.linkhub.domain.space.repository.common.dto;
+
+import com.tenten.linkhub.domain.space.model.space.Space;
+import com.tenten.linkhub.domain.space.model.space.SpaceImage;
+
+import java.util.List;
+
+public record SpaceAndSpaceImageOwnerNickName(
+        Space space,
+        List<SpaceImage> spaceImages,
+        String ownerNickName
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/common/dto/SpaceAndSpaceImageOwnerNickNames.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/common/dto/SpaceAndSpaceImageOwnerNickNames.java
@@ -1,0 +1,30 @@
+package com.tenten.linkhub.domain.space.repository.common.dto;
+
+import com.tenten.linkhub.domain.space.model.space.SpaceImage;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public record SpaceAndSpaceImageOwnerNickNames(
+        List<SpaceAndSpaceImageOwnerNickName> contents
+) {
+    public static SpaceAndSpaceImageOwnerNickNames of(List<SpaceAndOwnerNickName> spaceAndOwnerNickNames, List<SpaceImage> spaceImages) {
+        Map<Long, List<SpaceImage>> spaceImageMap = spaceImages
+                .stream()
+                .collect(Collectors.groupingBy(
+                        si -> si.getSpace().getId()
+                ));
+
+        List<SpaceAndSpaceImageOwnerNickName> mapSpaceAndSpaceImageOwnerNickNames = spaceAndOwnerNickNames
+                .stream()
+                .map(so -> new SpaceAndSpaceImageOwnerNickName(
+                        so.space(),
+                        spaceImageMap.get(so.space().getId()),
+                        so.ownerNickName()
+                ))
+                .collect(Collectors.toList());
+
+        return new SpaceAndSpaceImageOwnerNickNames(mapSpaceAndSpaceImageOwnerNickNames);
+    }
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/favorite/DefaultFavoriteRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/favorite/DefaultFavoriteRepository.java
@@ -2,6 +2,7 @@ package com.tenten.linkhub.domain.space.repository.favorite;
 
 import com.tenten.linkhub.domain.space.model.space.Favorite;
 import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.favorite.dto.MyFavoriteSpacesQueryCondition;
 import com.tenten.linkhub.domain.space.repository.favorite.query.FavoriteQueryRepository;
 import com.tenten.linkhub.global.exception.DataNotFoundException;
@@ -39,7 +40,7 @@ public class DefaultFavoriteRepository implements FavoriteRepository {
     }
 
     @Override
-    public Slice<SpaceAndOwnerNickName> findMyFavoriteSpacesByQuery(MyFavoriteSpacesQueryCondition queryCondition) {
+    public Slice<SpaceAndSpaceImageOwnerNickName> findMyFavoriteSpacesByQuery(MyFavoriteSpacesQueryCondition queryCondition) {
         return favoriteQueryRepository.findMyFavoriteSpacesByQuery(queryCondition);
     }
 

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/favorite/FavoriteRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/favorite/FavoriteRepository.java
@@ -2,6 +2,7 @@ package com.tenten.linkhub.domain.space.repository.favorite;
 
 import com.tenten.linkhub.domain.space.model.space.Favorite;
 import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.favorite.dto.MyFavoriteSpacesQueryCondition;
 import org.springframework.data.domain.Slice;
 
@@ -15,5 +16,5 @@ public interface FavoriteRepository {
 
     Long deleteById(Long favoriteId);
 
-    Slice<SpaceAndOwnerNickName> findMyFavoriteSpacesByQuery(MyFavoriteSpacesQueryCondition queryCondition);
+    Slice<SpaceAndSpaceImageOwnerNickName> findMyFavoriteSpacesByQuery(MyFavoriteSpacesQueryCondition queryCondition);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/DefaultSpaceRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/DefaultSpaceRepository.java
@@ -1,9 +1,10 @@
 package com.tenten.linkhub.domain.space.repository.space;
 
 import com.tenten.linkhub.domain.space.model.space.Space;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.space.dto.MySpacesQueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.dto.QueryCondition;
-import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.space.query.SpaceQueryRepository;
 import com.tenten.linkhub.global.exception.DataNotFoundException;
 import org.springframework.data.domain.Slice;
@@ -22,7 +23,7 @@ public class DefaultSpaceRepository implements SpaceRepository {
     }
 
     @Override
-    public Slice<SpaceAndOwnerNickName> findPublicSpacesJoinSpaceImageByQuery(QueryCondition queryCondition) {
+    public Slice<SpaceAndSpaceImageOwnerNickName> findPublicSpacesJoinSpaceImageByQuery(QueryCondition queryCondition) {
         return spaceQueryRepository.findPublicSpacesJoinSpaceImageByCondition(queryCondition);
     }
 
@@ -44,7 +45,7 @@ public class DefaultSpaceRepository implements SpaceRepository {
     }
 
     @Override
-    public Slice<SpaceAndOwnerNickName> findMySpacesJoinSpaceImageByQuery(MySpacesQueryCondition queryCondition) {
+    public Slice<SpaceAndSpaceImageOwnerNickName> findMySpacesJoinSpaceImageByQuery(MySpacesQueryCondition queryCondition) {
         return spaceQueryRepository.findMySpacesJoinSpaceImageByCondition(queryCondition);
     }
 

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/SpaceRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/SpaceRepository.java
@@ -1,14 +1,15 @@
 package com.tenten.linkhub.domain.space.repository.space;
 
 import com.tenten.linkhub.domain.space.model.space.Space;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.space.dto.MySpacesQueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.dto.QueryCondition;
-import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
 import org.springframework.data.domain.Slice;
 
 public interface SpaceRepository {
 
-    Slice<SpaceAndOwnerNickName> findPublicSpacesJoinSpaceImageByQuery(QueryCondition queryCondition);
+    Slice<SpaceAndSpaceImageOwnerNickName> findPublicSpacesJoinSpaceImageByQuery(QueryCondition queryCondition);
 
     Space save(Space space);
 
@@ -16,7 +17,7 @@ public interface SpaceRepository {
 
     Space getSpaceJoinSpaceMemberById(Long spaceId);
 
-    Slice<SpaceAndOwnerNickName> findMySpacesJoinSpaceImageByQuery(MySpacesQueryCondition mySpacesQueryCondition);
+    Slice<SpaceAndSpaceImageOwnerNickName> findMySpacesJoinSpaceImageByQuery(MySpacesQueryCondition mySpacesQueryCondition);
 
     void increaseFavoriteCount(Long spaceId);
 

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/query/SpaceQueryRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/query/SpaceQueryRepository.java
@@ -1,10 +1,13 @@
 package com.tenten.linkhub.domain.space.repository.space.query;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.repository.common.dto.QSpaceAndOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickNames;
 import com.tenten.linkhub.domain.space.repository.space.dto.MySpacesQueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.dto.QueryCondition;
-import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
@@ -13,6 +16,7 @@ import java.util.List;
 
 import static com.tenten.linkhub.domain.member.model.QMember.member;
 import static com.tenten.linkhub.domain.space.model.space.QSpace.space;
+import static com.tenten.linkhub.domain.space.model.space.QSpaceImage.spaceImage;
 import static com.tenten.linkhub.domain.space.model.space.QSpaceMember.spaceMember;
 
 @Repository
@@ -26,14 +30,13 @@ public class SpaceQueryRepository {
         this.dynamicQueryFactory = new DynamicQueryFactory();
     }
 
-    public Slice<SpaceAndOwnerNickName> findPublicSpacesJoinSpaceImageByCondition(QueryCondition condition) {
+    public Slice<SpaceAndSpaceImageOwnerNickName> findPublicSpacesJoinSpaceImageByCondition(QueryCondition condition) {
         List<SpaceAndOwnerNickName> spaceAndOwnerNickNames = queryFactory
                 .select(new QSpaceAndOwnerNickName(
                         space,
                         member.nickname
                 ))
                 .from(space)
-                .join(space.spaceImages.spaceImageList).fetchJoin()
                 .join(member).on(space.memberId.eq(member.id))
                 .where(space.isDeleted.eq(false),
                         space.isVisible.eq(true),
@@ -45,24 +48,30 @@ public class SpaceQueryRepository {
                 .limit(condition.pageable().getPageSize() + 1)
                 .fetch();
 
+        List<Long> spaceIds = getSpaceIds(spaceAndOwnerNickNames);
+
+        List<SpaceImage> spaceImages = findSpaceImagesBySpaceIds(spaceIds);
+
+        SpaceAndSpaceImageOwnerNickNames spaceAndSpaceImageOwnerNickNames = SpaceAndSpaceImageOwnerNickNames.of(spaceAndOwnerNickNames, spaceImages);
+
+        List<SpaceAndSpaceImageOwnerNickName> contents = spaceAndSpaceImageOwnerNickNames.contents();
         boolean hasNext = false;
 
-        if (spaceAndOwnerNickNames.size() > condition.pageable().getPageSize()) {
-            spaceAndOwnerNickNames.remove(condition.pageable().getPageSize());
+        if (contents.size() > condition.pageable().getPageSize()) {
+            contents.remove(condition.pageable().getPageSize());
             hasNext = true;
         }
 
-        return new SliceImpl<>(spaceAndOwnerNickNames, condition.pageable(), hasNext);
+        return new SliceImpl<>(contents, condition.pageable(), hasNext);
     }
 
-    public Slice<SpaceAndOwnerNickName> findMySpacesJoinSpaceImageByCondition(MySpacesQueryCondition condition) {
+    public Slice<SpaceAndSpaceImageOwnerNickName> findMySpacesJoinSpaceImageByCondition(MySpacesQueryCondition condition) {
         List<SpaceAndOwnerNickName> spaceAndOwnerNickNames = queryFactory
                 .select(new QSpaceAndOwnerNickName(
                         space,
                         member.nickname
                 ))
                 .from(space)
-                .leftJoin(space.spaceImages.spaceImageList).fetchJoin()
                 .join(space.spaceMembers.spaceMemberList, spaceMember)
                 .join(member).on(space.memberId.eq(member.id))
                 .where(spaceMember.memberId.eq(condition.memberId()),
@@ -74,14 +83,36 @@ public class SpaceQueryRepository {
                 .limit(condition.pageable().getPageSize() + 1)
                 .fetch();
 
+        List<Long> spaceIds = getSpaceIds(spaceAndOwnerNickNames);
+
+        List<SpaceImage> spaceImages = findSpaceImagesBySpaceIds(spaceIds);
+
+        SpaceAndSpaceImageOwnerNickNames spaceAndSpaceImageOwnerNickNames = SpaceAndSpaceImageOwnerNickNames.of(spaceAndOwnerNickNames, spaceImages);
+
+        List<SpaceAndSpaceImageOwnerNickName> contents = spaceAndSpaceImageOwnerNickNames.contents();
         boolean hasNext = false;
 
-        if (spaceAndOwnerNickNames.size() > condition.pageable().getPageSize()) {
-            spaceAndOwnerNickNames.remove(condition.pageable().getPageSize());
+        if (contents.size() > condition.pageable().getPageSize()) {
+            contents.remove(condition.pageable().getPageSize());
             hasNext = true;
         }
 
-        return new SliceImpl<>(spaceAndOwnerNickNames, condition.pageable(), hasNext);
+        return new SliceImpl<>(contents, condition.pageable(), hasNext);
+    }
+
+    private List<SpaceImage> findSpaceImagesBySpaceIds(List<Long> spaceIds) {
+        return queryFactory
+                .selectFrom(spaceImage)
+                .where(spaceImage.space.id.in(spaceIds),
+                        spaceImage.isDeleted.eq(false))
+                .fetch();
+    }
+
+    private static List<Long> getSpaceIds(List<SpaceAndOwnerNickName> spaceAndOwnerNickNames) {
+        return spaceAndOwnerNickNames
+                .stream()
+                .map(s -> s.space().getId())
+                .toList();
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
@@ -3,10 +3,10 @@ package com.tenten.linkhub.domain.space.service;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.favorite.FavoriteRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceRepository;
 import com.tenten.linkhub.domain.space.repository.space.dto.MySpacesQueryCondition;
-import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.spacemember.SpaceMemberRepository;
 import com.tenten.linkhub.domain.space.repository.tag.TagRepository;
 import com.tenten.linkhub.domain.space.repository.tag.dto.TagInfo;
@@ -43,9 +43,9 @@ public class DefaultSpaceService implements SpaceService {
     @Override
     @Transactional(readOnly = true)
     public PublicSpacesFindByQueryResponses findPublicSpacesByQuery(PublicSpacesFindByQueryRequest request) {
-        Slice<SpaceAndOwnerNickName> spaceAndOwnerNickNames = spaceRepository.findPublicSpacesJoinSpaceImageByQuery(mapper.toQueryCond(request));
+        Slice<SpaceAndSpaceImageOwnerNickName> spaceAndSpaceImageOwnerNickName = spaceRepository.findPublicSpacesJoinSpaceImageByQuery(mapper.toQueryCond(request));
 
-        return PublicSpacesFindByQueryResponses.from(spaceAndOwnerNickNames);
+        return PublicSpacesFindByQueryResponses.from(spaceAndSpaceImageOwnerNickName);
     }
 
     @Override
@@ -104,9 +104,9 @@ public class DefaultSpaceService implements SpaceService {
     @Transactional(readOnly = true)
     public PublicSpacesFindByQueryResponses findMySpacesByQuery(MySpacesFindRequest request) {
         MySpacesQueryCondition queryCondition = mapper.toMySpacesFindQueryCondition(request);
-        Slice<SpaceAndOwnerNickName> spaceAndOwnerNickNames = spaceRepository.findMySpacesJoinSpaceImageByQuery(queryCondition);
+        Slice<SpaceAndSpaceImageOwnerNickName> spaceAndSpaceImageOwnerNickName = spaceRepository.findMySpacesJoinSpaceImageByQuery(queryCondition);
 
-        return PublicSpacesFindByQueryResponses.from(spaceAndOwnerNickNames);
+        return PublicSpacesFindByQueryResponses.from(spaceAndSpaceImageOwnerNickName);
     }
 
     @Override

--- a/src/main/java/com/tenten/linkhub/domain/space/service/FavoriteService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/FavoriteService.java
@@ -4,7 +4,7 @@ import com.tenten.linkhub.domain.space.handler.dto.SpaceDecreaseFavoriteCountEve
 import com.tenten.linkhub.domain.space.handler.dto.SpaceIncreaseFavoriteCountEvent;
 import com.tenten.linkhub.domain.space.model.space.Favorite;
 import com.tenten.linkhub.domain.space.model.space.Space;
-import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.favorite.FavoriteRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceRepository;
 import com.tenten.linkhub.domain.space.repository.favorite.dto.MyFavoriteSpacesQueryCondition;
@@ -62,7 +62,7 @@ public class FavoriteService {
     public FavoriteSpacesFindResponses findMyFavoriteSpaces(MyFavoriteSpacesFindRequest request) {
         MyFavoriteSpacesQueryCondition queryCondition = mapper.toQueryCondition(request);
 
-        Slice<SpaceAndOwnerNickName> responses = favoriteRepository.findMyFavoriteSpacesByQuery(queryCondition);
+        Slice<SpaceAndSpaceImageOwnerNickName> responses = favoriteRepository.findMyFavoriteSpacesByQuery(queryCondition);
 
         return FavoriteSpacesFindResponses.from(responses);
     }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/favorite/FavoriteSpacesFindResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/favorite/FavoriteSpacesFindResponses.java
@@ -1,13 +1,14 @@
 package com.tenten.linkhub.domain.space.service.dto.favorite;
 
 import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
 import org.springframework.data.domain.Slice;
 
 import java.util.Objects;
 
 public record FavoriteSpacesFindResponses(Slice<FavoriteSpacesFindResponse> responses) {
 
-    public static FavoriteSpacesFindResponses from(Slice<SpaceAndOwnerNickName> response){
+    public static FavoriteSpacesFindResponses from(Slice<SpaceAndSpaceImageOwnerNickName> response){
         Slice<FavoriteSpacesFindResponse> mapResponses = response.map(s -> new FavoriteSpacesFindResponse(
                 s.space().getId(),
                 s.space().getSpaceName(),
@@ -20,7 +21,7 @@ public record FavoriteSpacesFindResponses(Slice<FavoriteSpacesFindResponse> resp
                 s.space().getViewCount(),
                 s.space().getScrapCount(),
                 s.space().getFavoriteCount(),
-                s.space().getSpaceImages().isEmpty() ? null : s.space().getSpaceImages().get(0).getPath(),
+                s.spaceImages().isEmpty() ? null : s.spaceImages().get(0).getPath(),
                 s.ownerNickName()
         ));
 

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/space/PublicSpacesFindByQueryResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/space/PublicSpacesFindByQueryResponses.java
@@ -1,13 +1,13 @@
 package com.tenten.linkhub.domain.space.service.dto.space;
 
-import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
 import org.springframework.data.domain.Slice;
 
 import java.util.Objects;
 
 public record PublicSpacesFindByQueryResponses(Slice<SpacesFindByQueryResponse> responses) {
 
-    public static PublicSpacesFindByQueryResponses from(Slice<SpaceAndOwnerNickName> response){
+    public static PublicSpacesFindByQueryResponses from(Slice<SpaceAndSpaceImageOwnerNickName> response){
         Slice<SpacesFindByQueryResponse> mapResponses = response.map(s -> new SpacesFindByQueryResponse(
                 s.space().getId(),
                 s.space().getSpaceName(),
@@ -20,7 +20,7 @@ public record PublicSpacesFindByQueryResponses(Slice<SpacesFindByQueryResponse> 
                 s.space().getViewCount(),
                 s.space().getScrapCount(),
                 s.space().getFavoriteCount(),
-                s.space().getSpaceImages().isEmpty() ? null : s.space().getSpaceImages().get(0).getPath(),
+                s.spaceImages().isEmpty() ? null : s.spaceImages().get(0).getPath(),
                 s.ownerNickName()
         ));
 

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
@@ -81,6 +81,7 @@ class DefaultSpaceServiceTest {
         //then
         List<SpacesFindByQueryResponse> content = responses.responses().getContent();
 
+        assertThat(content.size()).isEqualTo(1);
         assertThat(content.get(0).spaceName()).isEqualTo("첫번째 스페이스");
         assertThat(content.get(0).description()).isEqualTo("첫번째 스페이스 소개글");
         assertThat(content.get(0).category()).isEqualTo(Category.KNOWLEDGE_ISSUE_CAREER);
@@ -208,6 +209,10 @@ class DefaultSpaceServiceTest {
                 true,
                 true,
                 false
+        );
+
+        space1.addSpaceImage(
+                new SpaceImage("https://testimage4", "테스트 이미지4")
         );
 
         Space space2 = new Space(

--- a/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
@@ -180,10 +180,11 @@ class FavoriteServiceTest {
 
     @Test
     @DisplayName("유저는 자신이 즐겨찾기 등록한 스페이스를 키워드, 필터 조건 없이 조회할 수 있다.")
-    void findMyFavoriteSpaces_emptyKeyWord_emptyFilter() {
+    void findMyFavoriteSpaces_emptyKeyWord_emptyFilter() throws InterruptedException {
         //given
         favoriteService.createFavorite(setUpSpaceId1, setUpMemberId1);
         favoriteService.createFavorite(setUpSpaceId2, setUpMemberId1);
+        Thread.sleep(10);
 
         PageRequest pageRequest = PageRequest.of(0, 10);
         MyFavoriteSpacesFindRequest request = new MyFavoriteSpacesFindRequest(pageRequest, null, null, setUpMemberId1);

--- a/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
@@ -13,7 +13,6 @@ import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
 import com.tenten.linkhub.domain.space.repository.favorite.FavoriteJpaRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
-import com.tenten.linkhub.domain.space.repository.spacemember.SpaceMemberJpaRepository;
 import com.tenten.linkhub.domain.space.service.dto.favorite.FavoriteSpacesFindResponse;
 import com.tenten.linkhub.domain.space.service.dto.favorite.FavoriteSpacesFindResponses;
 import com.tenten.linkhub.domain.space.service.dto.favorite.MyFavoriteSpacesFindRequest;
@@ -245,6 +244,10 @@ class FavoriteServiceTest {
                 true,
                 true,
                 true
+        );
+
+        space1.addSpaceImage(
+                new SpaceImage("https://testimage2", "테스트 이미지2")
         );
 
         Space space2 = new Space(


### PR DESCRIPTION
## 작업한 일
- 스페이스 검색 API에서 이미지 두개 시 중복된 스페이스 조회되는 에러 해결.