### PR TITLE
Hotfix/send email - 이메일 발송 시 response 추가하도록 코드 수정

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/member/controller/dto/MailSendApiResponse.java
+++ b/src/main/java/com/tenten/linkhub/domain/member/controller/dto/MailSendApiResponse.java
@@ -1,0 +1,6 @@
+package com.tenten.linkhub.domain.member.controller.dto;
+
+public record MailSendApiResponse(
+        Long emailCodeDuration
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/member/controller/mapper/MemberApiMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/member/controller/mapper/MemberApiMapper.java
@@ -1,18 +1,20 @@
 package com.tenten.linkhub.domain.member.controller.mapper;
 
+import com.tenten.linkhub.domain.member.controller.dto.MailSendApiResponse;
 import com.tenten.linkhub.domain.member.controller.dto.MailVerificationApiRequest;
 import com.tenten.linkhub.domain.member.controller.dto.MailVerificationApiResponse;
 import com.tenten.linkhub.domain.member.controller.dto.MemberFollowCreateApiResponse;
 import com.tenten.linkhub.domain.member.controller.dto.MemberJoinApiRequest;
 import com.tenten.linkhub.domain.member.controller.dto.MemberMyProfileApiResponse;
 import com.tenten.linkhub.domain.member.controller.dto.MemberProfileApiResponse;
+import com.tenten.linkhub.domain.member.controller.dto.MemberSpacesFindApiRequest;
+import com.tenten.linkhub.domain.member.service.dto.MailSendResponse;
 import com.tenten.linkhub.domain.member.service.dto.MailVerificationRequest;
 import com.tenten.linkhub.domain.member.service.dto.MailVerificationResponse;
 import com.tenten.linkhub.domain.member.service.dto.MemberFollowCreateResponse;
 import com.tenten.linkhub.domain.member.service.dto.MemberJoinRequest;
 import com.tenten.linkhub.domain.member.service.dto.MemberMyProfileResponse;
 import com.tenten.linkhub.domain.member.service.dto.MemberProfileResponse;
-import com.tenten.linkhub.domain.member.controller.dto.MemberSpacesFindApiRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.MemberSpacesFindRequest;
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;
@@ -23,6 +25,8 @@ import org.springframework.web.multipart.MultipartFile;
         injectionStrategy = InjectionStrategy.CONSTRUCTOR
 )
 public interface MemberApiMapper {
+
+    MailSendApiResponse toMailSendApiResponse(MailSendResponse response);
 
     MailVerificationRequest toMailVerificationRequest(MailVerificationApiRequest request);
 

--- a/src/main/java/com/tenten/linkhub/domain/member/service/MemberService.java
+++ b/src/main/java/com/tenten/linkhub/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.tenten.linkhub.domain.member.service;
 
 import com.tenten.linkhub.domain.member.model.Provider;
+import com.tenten.linkhub.domain.member.service.dto.MailSendResponse;
 import com.tenten.linkhub.domain.member.service.dto.MailVerificationRequest;
 import com.tenten.linkhub.domain.member.service.dto.MailVerificationResponse;
 import com.tenten.linkhub.domain.member.service.dto.MemberFindResponse;
@@ -13,13 +14,13 @@ import com.tenten.linkhub.domain.member.service.dto.MemberJoinResponse;
 import com.tenten.linkhub.domain.member.service.dto.MemberMyProfileResponse;
 import com.tenten.linkhub.domain.member.service.dto.MemberProfileResponse;
 import com.tenten.linkhub.global.util.email.EmailDto;
+import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
-import org.springframework.data.domain.PageRequest;
 
 public interface MemberService {
 
-    void sendVerificationEmail(EmailDto emailDto);
+    MailSendResponse sendVerificationEmail(EmailDto emailDto);
 
     MailVerificationResponse verificateEmail(MailVerificationRequest request);
 

--- a/src/main/java/com/tenten/linkhub/domain/member/service/dto/MailSendResponse.java
+++ b/src/main/java/com/tenten/linkhub/domain/member/service/dto/MailSendResponse.java
@@ -1,0 +1,6 @@
+package com.tenten.linkhub.domain.member.service.dto;
+
+public record MailSendResponse(
+        Long emailCodeDuration
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
@@ -58,8 +58,10 @@ public class LinkController {
             description = "[JWT 필요] 스페이스 내에서 링크를 생성하는 API 입니다. TagName과 Color는 필수로 포함되어야 하는 값은 아닙니다. \n - TagName & Color를 포함하여 링크를 수정하는 경우: tagName & Color 필드 포함. 단, \"\" 나 \" \"를 허용하지 않습니다.\n - Tag를 포함하지 않고 링크를 생성하는 경우: 아예 tagName & Color 필드 없이 보내주세요",
             responses = {
                     @ApiResponse(responseCode = "201", description = "링크가 성공적으로 생성된 경우"),
-                    @ApiResponse(responseCode = "404", description = "링크 생성 권한이 없습니다."),
-                    @ApiResponse(responseCode = "404", description = "요청한 spaceId에 해당하는 스페이스를 찾을 수 없습니다.")
+                    @ApiResponse(responseCode = "404", description = "링크 생성 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "요청한 spaceId에 해당하는 스페이스를 찾을 수 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping(value = "/spaces/{spaceId}/links",
             consumes = MediaType.APPLICATION_JSON_VALUE,
@@ -89,9 +91,12 @@ public class LinkController {
             description = "[JWT 필요] 스페이스 내에서 링크를 수정하는 API 입니다. TagName과 Color는 필수로 포함되어야 하는 값은 아닙니다. \n - TagName & Color를 포함하여 링크를 수정하는 경우: tagName & Color 필드 포함. 단, \"\" 나 \" \"를 허용하지 않습니다.\n - Tag를 포함하지 않고 링크를 수정하는 경우: 아예 tagName & Color 필드 없이 보내주세요",
             responses = {
                     @ApiResponse(responseCode = "200", description = "링크가 성공적으로 수정된 경우"),
-                    @ApiResponse(responseCode = "404", description = "링크 수정 권한이 없습니다."),
-                    @ApiResponse(responseCode = "404", description = "요청한 spaceId에 해당하는 스페이스를 찾을 수 없습니다."),
-                    @ApiResponse(responseCode = "404", description = "요청한 linkId에 해당하는 스페이스를 찾을 수 없습니다.")
+                    @ApiResponse(responseCode = "404", description = "링크 수정 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "요청한 spaceId에 해당하는 스페이스를 찾을 수 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "요청한 linkId에 해당하는 스페이스를 찾을 수 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PutMapping(value = "/spaces/{spaceId}/links/{linkId}",
             consumes = MediaType.APPLICATION_JSON_VALUE,
@@ -190,9 +195,12 @@ public class LinkController {
             description = "[JWT 필요] 스페이스 내에서 링크를 삭제하는 API 입니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "링크가 성공적으로 삭제된 경우"),
-                    @ApiResponse(responseCode = "404", description = "링크 삭제 권한이 없습니다."),
-                    @ApiResponse(responseCode = "404", description = "요청한 spaceId에 해당하는 스페이스를 찾을 수 없습니다."),
-                    @ApiResponse(responseCode = "404", description = "요청한 linkId에 해당하는 스페이스를 찾을 수 없습니다.")
+                    @ApiResponse(responseCode = "404", description = "링크 삭제 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "요청한 spaceId에 해당하는 스페이스를 찾을 수 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "요청한 linkId에 해당하는 스페이스를 찾을 수 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @DeleteMapping(value = "/spaces/{spaceId}/links/{linkId}")
     public ResponseEntity<Void> deleteLink(
@@ -218,7 +226,8 @@ public class LinkController {
             " - tagId: 필터링하고자 하는 태그의 tagId를 넣어주세요. \n ",
             responses = {
                     @ApiResponse(responseCode = "200", description = "검색이 성공적으로 완료 되었습니다."),
-                    @ApiResponse(responseCode = "404", description = "링크를 조회할 수 있는 권한이 없습니다."),
+                    @ApiResponse(responseCode = "404", description = "링크를 조회할 수 있는 권한이 없습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
             })
     @GetMapping(value = "/spaces/{spaceId}/links")
     public ResponseEntity<LinksGetWithFilterApiResponses> getLinks(


### PR DESCRIPTION
## 🔗 이슈
#136

## 📒 구현 내용 📒

### 이메일 발송 API 수정
- response에 인증번호 유효시간 반환하도록 수정