### PR TITLE
[Fix]: 루트댓글 페이징 조회 시 대댓글 카운트 방식 변경.  -  루트 댓글 페이징 조회 시 대댓글 카운트 방식 변경

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/repository/comment/query/CommentQueryRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/comment/query/CommentQueryRepository.java
@@ -33,7 +33,8 @@ public class CommentQueryRepository {
                         JPAExpressions
                                 .select(subComment.count())
                                 .from(subComment)
-                                .where(subComment.parentComment.id.eq(comment.id))
+                                .where(subComment.groupNumber.eq(comment.id),
+                                        subComment.isDeleted.eq(false))
                 ))
                 .from(comment)
                 .where(comment.isDeleted.eq(false),

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/CommentFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/CommentFacadeTest.java
@@ -84,7 +84,7 @@ class CommentFacadeTest {
         assertThat(content.get(0).content()).isEqualTo("첫번째 루트 댓글");
         assertThat(content.get(0).nickname()).isEqualTo("잠자는 사자의 콧털");
         assertThat(content.get(0).profileImagePath()).isEqualTo("https://testprofileimage");
-        assertThat(content.get(0).childCount()).isEqualTo(2);
+        assertThat(content.get(0).childCount()).isEqualTo(4);
         assertThat(content.get(0).isModifiable()).isTrue();
 
         assertThat(content.get(1).content()).isEqualTo("두번째 루트 댓글");


### PR DESCRIPTION
## 작업한 일
- 루트댓글 페이징 조회 시 대댓글 카운트 조건 변경 및 누락된 isDeleted = false 추가.