### PR TITLE
Feature/get popular links - 인기있는 링크 리스트 조회 API 

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
@@ -264,6 +264,11 @@ public class LinkController {
     /**
      * 인기 있는 링크 리스트 조회
      */
+    @Operation(
+            summary = "인기 있는 링크 조회 API", description = "랜딩 페이지에서 인기있는 리스트를 조회할 때 사용하는 API 입니다. \n  로그인이 되어있다면 JWT를 넣어 요청 보내주시면 됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "인기 있는 링크 조회가 성공적으로 완료 되었습니다.")
+            })
     @GetMapping("/links/popular")
     public ResponseEntity<PopularLinksGetApiResponses> getPopularLinks(
             @AuthenticationPrincipal MemberDetails memberDetails

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/LinkController.java
@@ -8,12 +8,15 @@ import com.tenten.linkhub.domain.space.controller.dto.link.LinkUpdateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.link.LinkUpdateApiResponse;
 import com.tenten.linkhub.domain.space.controller.dto.link.LinksGetWithFilterApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.link.LinksGetWithFilterApiResponses;
+import com.tenten.linkhub.domain.space.controller.dto.link.PopularLinksGetApiResponses;
 import com.tenten.linkhub.domain.space.controller.mapper.LinkApiMapper;
 import com.tenten.linkhub.domain.space.facade.LinkFacade;
 import com.tenten.linkhub.domain.space.facade.dto.LinkCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.dto.LinkUpdateFacadeRequest;
+import com.tenten.linkhub.domain.space.service.LinkService;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkGetByQueryResponses;
 import com.tenten.linkhub.domain.space.service.dto.link.LinksGetByQueryRequest;
+import com.tenten.linkhub.domain.space.service.dto.link.PopularLinksGetByQueryResponses;
 import com.tenten.linkhub.global.response.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -41,13 +44,16 @@ import java.util.Objects;
 @RestController
 public class LinkController {
     private static final String LINK_LOCATION_PREFIX = "https://api.Link-hub.site/links/";
-
     private final LinkFacade linkFacade;
+    private final LinkService linkService;
     private final LinkApiMapper mapper;
 
-    public LinkController(LinkFacade linkFacade, LinkApiMapper mapper) {
+    public LinkController(LinkFacade linkFacade,
+                          LinkApiMapper mapper,
+                          LinkService linkService) {
         this.linkFacade = linkFacade;
         this.mapper = mapper;
+        this.linkService = linkService;
     }
 
     /**
@@ -218,8 +224,6 @@ public class LinkController {
     /**
      * 링크 조회 API
      */
-
-
     @Operation(
             summary = "링크 조회 API", description = "- tagId, pageNumber, pageSize, sort를 받아 검색합니다.(sort, filter 조건 없이 사용할 수 있습니다.) \n " +
             " - sort: {created_at, popular} -> sort를 넣어주지 않을 경우 default는 created_at입니다. \n " +
@@ -255,6 +259,23 @@ public class LinkController {
         return ResponseEntity
                 .ok()
                 .body(response);
+    }
+
+    /**
+     * 인기 있는 링크 리스트 조회
+     */
+    @GetMapping("/links/popular")
+    public ResponseEntity<PopularLinksGetApiResponses> getPopularLinks(
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        Long memberId = Objects.isNull(memberDetails) ? null : memberDetails.memberId();
+
+        PopularLinksGetByQueryResponses responses = linkService.getPopularLinks(memberId);
+        PopularLinksGetApiResponses apiResponses = PopularLinksGetApiResponses.from(responses);
+
+        return ResponseEntity
+                .ok()
+                .body(apiResponses);
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/PopularLinksGetApiResponse.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/PopularLinksGetApiResponse.java
@@ -1,0 +1,12 @@
+package com.tenten.linkhub.domain.space.controller.dto.link;
+
+public record PopularLinksGetApiResponse(
+        Long linkId,
+        String title,
+        String url,
+        String tagName,
+        String tagColor,
+        Long likeCount,
+        boolean isLiked
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/PopularLinksGetApiResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/link/PopularLinksGetApiResponses.java
@@ -1,0 +1,26 @@
+package com.tenten.linkhub.domain.space.controller.dto.link;
+
+import com.tenten.linkhub.domain.space.service.dto.link.PopularLinksGetByQueryResponses;
+
+import java.util.List;
+
+public record PopularLinksGetApiResponses(
+        List<PopularLinksGetApiResponse> responses
+) {
+    public static PopularLinksGetApiResponses from(PopularLinksGetByQueryResponses responses) {
+        List<PopularLinksGetApiResponse> linkResponses = responses.responses()
+                .stream()
+                .map(l -> new PopularLinksGetApiResponse(
+                        l.linkId(),
+                        l.title(),
+                        l.url(),
+                        l.tagName(),
+                        l.tagColor(),
+                        l.likeCount(),
+                        l.isLiked()
+                ))
+                .toList();
+
+        return new PopularLinksGetApiResponses(linkResponses);
+    }
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/DefaultLinkRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/DefaultLinkRepository.java
@@ -3,11 +3,13 @@ package com.tenten.linkhub.domain.space.repository.link;
 import com.tenten.linkhub.domain.space.model.link.Link;
 import com.tenten.linkhub.domain.space.repository.link.dto.LinkGetDto;
 import com.tenten.linkhub.domain.space.repository.link.dto.LinkGetQueryCondition;
+import com.tenten.linkhub.domain.space.repository.link.dto.PopularLinkGetDto;
 import com.tenten.linkhub.domain.space.repository.link.querydsl.LinkQueryDslRepository;
 import com.tenten.linkhub.global.exception.DataNotFoundException;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -41,6 +43,11 @@ public class DefaultLinkRepository implements LinkRepository {
     @Override
     public Slice<LinkGetDto> getLinksByCondition(LinkGetQueryCondition condition) {
         return linkQueryDslRepository.getLinksByCondition(condition);
+    }
+
+    @Override
+    public List<PopularLinkGetDto> getPopularLinks(Long memberId) {
+        return linkQueryDslRepository.getPopularLinks(memberId);
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/LinkRepository.java
@@ -3,8 +3,10 @@ package com.tenten.linkhub.domain.space.repository.link;
 import com.tenten.linkhub.domain.space.model.link.Link;
 import com.tenten.linkhub.domain.space.repository.link.dto.LinkGetDto;
 import com.tenten.linkhub.domain.space.repository.link.dto.LinkGetQueryCondition;
+import com.tenten.linkhub.domain.space.repository.link.dto.PopularLinkGetDto;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LinkRepository {
@@ -16,4 +18,6 @@ public interface LinkRepository {
     Optional<Link> findById(Long linkId);
 
     Slice<LinkGetDto> getLinksByCondition(LinkGetQueryCondition condition);
+
+    List<PopularLinkGetDto> getPopularLinks(Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/dto/PopularLinkGetDto.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/dto/PopularLinkGetDto.java
@@ -1,0 +1,31 @@
+package com.tenten.linkhub.domain.space.repository.link.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.tenten.linkhub.domain.space.model.link.Color;
+
+public record PopularLinkGetDto(
+        Long linkId,
+        String title,
+        String url,
+        String tagName,
+        Color tagColor,
+        Long likeCount,
+        boolean isLiked
+) {
+    @QueryProjection
+    public PopularLinkGetDto(Long linkId,
+                             String title,
+                             String url,
+                             String tagName,
+                             Color tagColor,
+                             Long likeCount,
+                             boolean isLiked) {
+        this.linkId = linkId;
+        this.title = title;
+        this.url = url;
+        this.tagName = tagName;
+        this.tagColor = tagColor;
+        this.likeCount = likeCount;
+        this.isLiked = isLiked;
+    }
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultLinkService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultLinkService.java
@@ -12,6 +12,7 @@ import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.repository.like.LikeRepository;
 import com.tenten.linkhub.domain.space.repository.link.LinkRepository;
 import com.tenten.linkhub.domain.space.repository.link.dto.LinkGetDto;
+import com.tenten.linkhub.domain.space.repository.link.dto.PopularLinkGetDto;
 import com.tenten.linkhub.domain.space.repository.linkview.LinkViewRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceRepository;
 import com.tenten.linkhub.domain.space.repository.tag.TagRepository;
@@ -19,6 +20,7 @@ import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkGetByQueryResponses;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkUpdateRequest;
 import com.tenten.linkhub.domain.space.service.dto.link.LinksGetByQueryRequest;
+import com.tenten.linkhub.domain.space.service.dto.link.PopularLinksGetByQueryResponses;
 import com.tenten.linkhub.domain.space.service.mapper.LinkMapper;
 import com.tenten.linkhub.global.exception.DataNotFoundException;
 import com.tenten.linkhub.global.exception.UnauthorizedAccessException;
@@ -26,6 +28,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -145,6 +148,13 @@ public class DefaultLinkService implements LinkService {
     public LinkGetByQueryResponses getLinks(LinksGetByQueryRequest request) {
         Slice<LinkGetDto> linkGetDtos = linkRepository.getLinksByCondition(linkMapper.toQueryCondition(request));
         LinkGetByQueryResponses responses = LinkGetByQueryResponses.from(linkGetDtos);
+        return responses;
+    }
+
+    @Override
+    public PopularLinksGetByQueryResponses getPopularLinks(Long memberId) {
+        List<PopularLinkGetDto> popularLinks = linkRepository.getPopularLinks(memberId);
+        PopularLinksGetByQueryResponses responses = PopularLinksGetByQueryResponses.from(popularLinks);
         return responses;
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/LinkService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/LinkService.java
@@ -4,6 +4,7 @@ import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkGetByQueryResponses;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkUpdateRequest;
 import com.tenten.linkhub.domain.space.service.dto.link.LinksGetByQueryRequest;
+import com.tenten.linkhub.domain.space.service.dto.link.PopularLinksGetByQueryResponses;
 
 public interface LinkService {
 
@@ -21,4 +22,5 @@ public interface LinkService {
 
     LinkGetByQueryResponses getLinks(LinksGetByQueryRequest request);
 
+    PopularLinksGetByQueryResponses getPopularLinks(Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/PopularLinksGetByQueryResponse.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/PopularLinksGetByQueryResponse.java
@@ -1,0 +1,12 @@
+package com.tenten.linkhub.domain.space.service.dto.link;
+
+public record PopularLinksGetByQueryResponse(
+        Long linkId,
+        String title,
+        String url,
+        String tagName,
+        String tagColor,
+        Long likeCount,
+        boolean isLiked
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/PopularLinksGetByQueryResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/PopularLinksGetByQueryResponses.java
@@ -1,0 +1,29 @@
+package com.tenten.linkhub.domain.space.service.dto.link;
+
+import com.tenten.linkhub.domain.space.repository.link.dto.PopularLinkGetDto;
+
+import java.util.List;
+import java.util.Objects;
+
+public record PopularLinksGetByQueryResponses(
+        List<PopularLinksGetByQueryResponse> responses
+) {
+    public static PopularLinksGetByQueryResponses from(List<PopularLinkGetDto> popularLinkGetDtos) {
+        List<PopularLinksGetByQueryResponse> responseList = popularLinkGetDtos
+                .stream()
+                .map(
+                        dto -> new PopularLinksGetByQueryResponse(
+                                dto.linkId(),
+                                dto.title(),
+                                dto.url(),
+                                dto.tagName(),
+                                Objects.isNull(dto.tagColor()) ? null : dto.tagColor().getValue(),
+                                dto.likeCount(),
+                                dto.isLiked()
+                        )
+                )
+                .toList();
+
+        return new PopularLinksGetByQueryResponses(responseList);
+    }
+}


### PR DESCRIPTION
## 🔗 이슈
#27 

## 📒 구현 내용 📒

### 인기 있는 링크 리스트 조회 기능 구현
- 랜딩페이지에서 사용하는 인기 있는 링크 리스트 조회 기능 구현
- 좋아요 여부 확인 추가
- 삭제된 링크, 삭제된 스페이스의 링크는 조회되지 않도록 했습니다.
- Swagger 코드 작성
- 테스트코드 작성