### PR TITLE
Hotfix/get tags - 태그 목록 조회 API 수정

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/querydsl/LinkQueryDslRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/querydsl/LinkQueryDslRepository.java
@@ -12,8 +12,6 @@ import com.tenten.linkhub.domain.space.repository.link.dto.LinkGetQueryCondition
 import com.tenten.linkhub.domain.space.repository.link.dto.LinkViewDto;
 import com.tenten.linkhub.domain.space.repository.link.dto.PopularLinkGetDto;
 import com.tenten.linkhub.domain.space.repository.link.dto.QPopularLinkGetDto;
-import com.tenten.linkhub.domain.space.repository.tag.dto.QTagInfo;
-import com.tenten.linkhub.domain.space.repository.tag.dto.TagInfo;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -113,18 +111,6 @@ public class LinkQueryDslRepository {
                         space.isDeleted.eq(Boolean.FALSE))
                 .orderBy(link.likeCount.desc())
                 .limit(5)
-                .fetch();
-    }
-
-    public List<TagInfo> findTagBySpaceIdAndGroupBySpaceName(Long spaceId) {
-        return jpaQueryFactory
-                .select(new QTagInfo(
-                        tag.name,
-                        tag.color,
-                        tag.id
-                ))
-                .from(tag)
-                .where(tag.space.id.eq(spaceId))
                 .fetch();
     }
 

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/tag/DefaultJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/tag/DefaultJpaRepository.java
@@ -23,7 +23,7 @@ public class DefaultJpaRepository implements TagRepository {
 
     @Override
     public List<TagInfo> findTagBySpaceId(Long spaceId) {
-        return tagQueryRepository.findTagBySpaceIdAndGroupBySpaceName(spaceId);
+        return tagQueryRepository.findTagBySpaceId(spaceId);
     }
 
     @Override

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/tag/DefaultTagRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/tag/DefaultTagRepository.java
@@ -9,13 +9,13 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public class DefaultJpaRepository implements TagRepository {
+public class DefaultTagRepository implements TagRepository {
 
     private final TagQueryRepository tagQueryRepository;
     private final TagJpaRepository tagJpaRepository;
     private final TagJdbcRepository tagJdbcRepository;
 
-    public DefaultJpaRepository(TagQueryRepository tagQueryRepository, TagJpaRepository tagJpaRepository, TagJdbcRepository tagJdbcRepository) {
+    public DefaultTagRepository(TagQueryRepository tagQueryRepository, TagJpaRepository tagJpaRepository, TagJdbcRepository tagJdbcRepository) {
         this.tagQueryRepository = tagQueryRepository;
         this.tagJpaRepository = tagJpaRepository;
         this.tagJdbcRepository = tagJdbcRepository;

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/tag/query/TagQueryRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/tag/query/TagQueryRepository.java
@@ -20,7 +20,7 @@ public class TagQueryRepository {
         this.jpaQueryFactory = jpaQueryFactory;
     }
 
-    public List<TagInfo> findTagBySpaceIdAndGroupBySpaceName(Long spaceId) {
+    public List<TagInfo> findTagBySpaceId(Long spaceId) {
         return jpaQueryFactory
                 .select(new QTagInfo(
                         tag.name,

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/tag/query/TagQueryRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/tag/query/TagQueryRepository.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.repository.tag.query;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tenten.linkhub.domain.space.repository.tag.dto.QTagInfo;
 import com.tenten.linkhub.domain.space.repository.tag.dto.TagInfo;
@@ -7,7 +8,9 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.tenten.linkhub.domain.space.model.link.QLinkTag.linkTag;
 import static com.tenten.linkhub.domain.space.model.link.QTag.tag;
+import static java.lang.Boolean.FALSE;
 
 @Repository
 public class TagQueryRepository {
@@ -25,8 +28,13 @@ public class TagQueryRepository {
                         tag.id
                 ))
                 .from(tag)
-                .where(tag.space.id.eq(spaceId))
+                .join(linkTag).on(linkTag.tag.eq(tag))
+                .groupBy(tag)
+                .where(tag.space.id.eq(spaceId), isActiveTag())
                 .fetch();
     }
 
+    private BooleanExpression isActiveTag() {
+        return linkTag.isDeleted.eq(FALSE);
+    }
 }

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
@@ -188,6 +188,23 @@ class DefaultSpaceServiceTest {
     }
 
     @Test
+    @DisplayName("스페이스에서 사용된 태그 목록을 조회 시 더이상 스페이스 내에서 사용하지 않는 태그는 조회되지 않는다.")
+    void getTagsBySpaceId_spaceId2_Success() {
+        //given - 링크 2개를 저장 후 그 중 하나를 삭제
+        Space space = spaceJpaRepository.findById(myFirstSpaceId).get();
+        Long linkId1 = linkFacade.createLink(myFirstSpaceId, myMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목A", "태그1", "gray"));
+        Long linkId2 = linkFacade.createLink(myFirstSpaceId, myMemberId, new LinkCreateFacadeRequest("https://www.naver.com", "제목C", "태그2", "red"));
+        linkFacade.deleteLink(space.getId(), linkId2, myMemberId);
+
+        //when
+        SpaceTagGetResponses response = spaceService.getTagsBySpaceId(myFirstSpaceId);
+
+        //then
+        assertThat(response.tags()).hasSize(1);
+        assertThat(response.tags().get(0).name()).isEqualTo("태그1");
+    }
+
+    @Test
     @DisplayName("스페이스에서 읽음 처리 기능을 활성화하지 않았다면 이력을 저장할 수 없다.")
     void checkLinkViewHistory_MemberIdAndSpaceId_ThrowsException() {
         //when & then


### PR DESCRIPTION

## 📒 구현 내용 📒

### 태그 목록 조회 API 수정
- 더이상 스페이스 내에서 링크와 함께 사용되지 않는 태그들은 조회되지 않도록 수정했습니다.
- 변경된 기획과 관련하여 테스트코드를 추가했습니다.