### PR TITLE
Feat/leave space/yyw. -  스페이스 나가기 API 외 스페이스 도메인 관련 로직 변경.

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
@@ -588,6 +588,13 @@ public class SpaceController {
     /**
      *  스페이스 나가기 API
      */
+    @Operation(
+            summary = "스페이스 나가기 API", description = "스페이스 나가기 API 입니다.",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "스페이스 나가기가 성공적으로 수행되었습니다."),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 스페이스 / 존재하지 않는 스페이스 멤버",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
     @DeleteMapping(value = "/{spaceId}/join")
     public ResponseEntity<Void> leaveSpace(
             @AuthenticationPrincipal MemberDetails memberDetails,

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
@@ -585,6 +585,19 @@ public class SpaceController {
                 .body(apiResponse);
     }
 
+    /**
+     *  스페이스 나가기 API
+     */
+    @DeleteMapping(value = "/{spaceId}/join")
+    public ResponseEntity<Void> leaveSpace(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @PathVariable Long spaceId
+    ) {
+        spaceService.deleteSpaceMemberByMe(spaceId, memberDetails.memberId());
+
+        return ResponseEntity.noContent().build();
+    }
+
     private void setSpaceViewCookie(HttpServletResponse servletResponse, List<Long> spaceViews) {
         String spaceViewCookieValue = spaceViews.toString()
                 .replace(",", "_")

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/Space.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/Space.java
@@ -225,4 +225,8 @@ public class Space extends BaseEntity {
         }
     }
 
+    public void deleteSpaceMember(Long memberId) {
+        spaceMembers.deleteSpaceMember(memberId);
+    }
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/Space.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/Space.java
@@ -199,7 +199,7 @@ public class Space extends BaseEntity {
     }
 
     public void changeSpaceMembersRole(Long targetMemberId, Role role) {
-        spaceMembers.changeSpaceMembersRole(targetMemberId, role);
+        memberId = spaceMembers.changeSpaceMembersRole(targetMemberId, role);
     }
 
     public Long deleteSpace(Long memberId) {

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/SpaceMember.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/SpaceMember.java
@@ -78,4 +78,17 @@ public class SpaceMember extends BaseEntity {
         return !Objects.equals(this.role, Role.CAN_VIEW);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SpaceMember that = (SpaceMember) o;
+        return Objects.equals(id, that.id) && Objects.equals(space, that.space) && Objects.equals(memberId, that.memberId) && role == that.role;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, space, memberId, role);
+    }
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/SpaceMember.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/SpaceMember.java
@@ -78,17 +78,4 @@ public class SpaceMember extends BaseEntity {
         return !Objects.equals(this.role, Role.CAN_VIEW);
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        SpaceMember that = (SpaceMember) o;
-        return Objects.equals(id, that.id) && Objects.equals(space, that.space) && Objects.equals(memberId, that.memberId) && role == that.role;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(id, space, memberId, role);
-    }
-
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceImages.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceImages.java
@@ -20,7 +20,7 @@ import static com.tenten.linkhub.global.util.CommonValidator.validateNotNull;
 @NoArgsConstructor
 public class SpaceImages {
 
-    @OneToMany(mappedBy = "space", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "space", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SpaceImage> spaceImageList = new ArrayList<>();
 
     public void addSpaceImage(SpaceImage spaceImage) {

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
@@ -93,4 +93,14 @@ public class SpaceMembers {
         targetSpaceMember.changeRole(role);
     }
 
+    public void deleteSpaceMember(Long memberId) {
+        SpaceMember spaceMember = getSpaceMemberList()
+                .stream()
+                .filter(sm -> Objects.equals(sm.getMemberId(), memberId))
+                .findFirst()
+                .orElseThrow(() -> new DataNotFoundException("해당하는 스페이스 멤버가 존재하지 않습니다."));
+
+        spaceMember.deleteSpaceMember();
+    }
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
@@ -87,19 +87,24 @@ public class SpaceMembers {
                 .anyMatch(sm -> Objects.equals(sm.getMemberId(), memberId) && !sm.getIsDeleted());
     }
 
-    public void changeSpaceMembersRole(Long targetMemberId, Role role) {
+    public Long changeSpaceMembersRole(Long targetMemberId, Role role) {
         SpaceMember targetSpaceMember = getSpaceMemberList()
                 .stream()
                 .filter(sm -> Objects.equals(sm.getMemberId(), targetMemberId))
                 .findFirst()
                 .orElseThrow(() -> new DataNotFoundException("해당 스페이스멤버를 찾지 못했습니다."));
 
+        SpaceMember spaceOwner = getSpaceOwner();
+
         if (Objects.equals(role, OWNER)) {
-            SpaceMember spaceOwner = getSpaceOwner();
             spaceOwner.changeRole(CAN_EDIT);
+
+            targetSpaceMember.changeRole(role);
+            return targetSpaceMember.getMemberId();
         }
 
         targetSpaceMember.changeRole(role);
+        return spaceOwner.getMemberId();
     }
 
     public void deleteSpaceMember(Long memberId) {

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
@@ -109,6 +109,10 @@ public class SpaceMembers {
                 .findFirst()
                 .orElseThrow(() -> new DataNotFoundException("해당하는 스페이스 멤버가 존재하지 않습니다."));
 
+        if (Objects.equals(spaceMember.getRole(), OWNER)) {
+            throw new IllegalStateException("스페이스의 주인은 스페이스를 나갈 수 없습니다. 나가기 대신 스페이스 삭제를 해주세요.");
+        }
+
         spaceMember.deleteSpaceMember();
     }
 

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
@@ -98,7 +98,7 @@ public class SpaceMembers {
             SpaceMember spaceOwner = getSpaceOwner();
             spaceOwner.changeRole(CAN_EDIT);
         }
-        
+
         targetSpaceMember.changeRole(role);
     }
 

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
@@ -27,7 +27,7 @@ import static com.tenten.linkhub.global.util.CommonValidator.validateNotNull;
 @NoArgsConstructor
 public class SpaceMembers {
 
-    @OneToMany(mappedBy = "space", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @OneToMany(mappedBy = "space", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SpaceMember> spaceMemberList = new ArrayList<>();
 
     public void addSpaceMember(SpaceMember spaceMember) {

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
@@ -9,6 +9,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.OneToMany;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -29,6 +30,7 @@ public class SpaceMembers {
 
     public void addSpaceMember(SpaceMember spaceMember) {
         validateNotNull(spaceMember, "spaceImages");
+        validateDuplicationSpaceMember(spaceMember);
 
         this.spaceMemberList.add(spaceMember);
     }
@@ -101,6 +103,12 @@ public class SpaceMembers {
                 .orElseThrow(() -> new DataNotFoundException("해당하는 스페이스 멤버가 존재하지 않습니다."));
 
         spaceMember.deleteSpaceMember();
+    }
+
+    public void validateDuplicationSpaceMember(SpaceMember spaceMember) {
+        if (getSpaceMemberList().contains(spaceMember)) {
+            throw new DuplicateKeyException("해당 멤버는 이미 스페이스의 멤버입니다.");
+        }
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
@@ -18,6 +18,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static com.tenten.linkhub.domain.space.model.space.Role.CAN_EDIT;
+import static com.tenten.linkhub.domain.space.model.space.Role.OWNER;
 import static com.tenten.linkhub.global.util.CommonValidator.validateNotNull;
 
 @Getter
@@ -92,6 +94,11 @@ public class SpaceMembers {
                 .findFirst()
                 .orElseThrow(() -> new DataNotFoundException("해당 스페이스멤버를 찾지 못했습니다."));
 
+        if (Objects.equals(role, OWNER)) {
+            SpaceMember spaceOwner = getSpaceOwner();
+            spaceOwner.changeRole(CAN_EDIT);
+        }
+        
         targetSpaceMember.changeRole(role);
     }
 
@@ -109,6 +116,14 @@ public class SpaceMembers {
         if (getSpaceMemberIds().contains(memberId)) {
             throw new DuplicateKeyException("해당 멤버는 이미 스페이스의 멤버입니다.");
         }
+    }
+
+    private SpaceMember getSpaceOwner() {
+        return getSpaceMemberList()
+                .stream()
+                .filter(sm -> Objects.equals(sm.getRole(), OWNER))
+                .findFirst()
+                .orElseThrow(() -> new DataNotFoundException("해당 스페이스에 Owner가 존재하지 않습니디."));
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/model/space/vo/SpaceMembers.java
@@ -30,7 +30,7 @@ public class SpaceMembers {
 
     public void addSpaceMember(SpaceMember spaceMember) {
         validateNotNull(spaceMember, "spaceImages");
-        validateDuplicationSpaceMember(spaceMember);
+        validateDuplicationSpaceMember(spaceMember.getMemberId());
 
         this.spaceMemberList.add(spaceMember);
     }
@@ -105,8 +105,8 @@ public class SpaceMembers {
         spaceMember.deleteSpaceMember();
     }
 
-    public void validateDuplicationSpaceMember(SpaceMember spaceMember) {
-        if (getSpaceMemberList().contains(spaceMember)) {
+    public void validateDuplicationSpaceMember(Long memberId) {
+        if (getSpaceMemberIds().contains(memberId)) {
             throw new DuplicateKeyException("해당 멤버는 이미 스페이스의 멤버입니다.");
         }
     }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
@@ -191,4 +191,12 @@ public class DefaultSpaceService implements SpaceService {
         return savedSpaceId;
     }
 
+    @Override
+    @Transactional
+    public void deleteSpaceMemberByMe(Long spaceId, Long memberId) {
+        Space space = spaceRepository.getById(spaceId);
+
+        space.deleteSpaceMember(memberId);
+    }
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
@@ -38,4 +38,6 @@ public interface SpaceService {
     void validateScrapTargetSpace(Long spaceId, Long memberId);
 
     Long createSpaceAndCopyLinks(NewSpacesScrapRequest request);
+
+    void deleteSpaceMemberByMe(Long spaceId, Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
+++ b/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
@@ -51,7 +51,7 @@ public class GlobalApiExceptionHandler {
         ErrorResponse errorResponse = ErrorResponse.of(e.getMessage(), request.getRequestURI());
 
         return ResponseEntity
-                .status(HttpStatus.BAD_REQUEST)
+                .status(HttpStatus.FORBIDDEN)
                 .body(errorResponse);
     }
 

--- a/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
+++ b/src/main/java/com/tenten/linkhub/global/exception/GlobalApiExceptionHandler.java
@@ -4,6 +4,7 @@ import com.tenten.linkhub.global.response.ErrorResponse;
 import com.tenten.linkhub.global.response.ErrorWithDetailCodeResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -47,6 +48,15 @@ public class GlobalApiExceptionHandler {
 
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ErrorResponse> handleIllegalStateException(HttpServletRequest request, IllegalStateException e) {
+        ErrorResponse errorResponse = ErrorResponse.of(e.getMessage(), request.getRequestURI());
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(errorResponse);
+    }
+
+    @ExceptionHandler(DuplicateKeyException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicateKeyException(HttpServletRequest request, DuplicateKeyException e) {
         ErrorResponse errorResponse = ErrorResponse.of(e.getMessage(), request.getRequestURI());
 
         return ResponseEntity

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/SpaceInvitationFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/SpaceInvitationFacadeTest.java
@@ -19,11 +19,13 @@ import com.tenten.linkhub.domain.space.repository.invitation.InvitationJpaReposi
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
 import com.tenten.linkhub.domain.space.service.dto.invitation.SpaceInvitationAcceptRequest;
 import com.tenten.linkhub.global.exception.UnauthorizedAccessException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -118,6 +120,18 @@ class SpaceInvitationFacadeTest {
         //when//then
         assertThatThrownBy(() -> spaceInvitationFacade.acceptSpaceInvitation(request))
                 .isInstanceOf(UnauthorizedAccessException.class);
+    }
+
+    @Test
+    @DisplayName("유저가 스페이스 초대를 중복 수락할 경우 해당 DuplicateKeyException가 발생한다.")
+    void acceptSpaceInvitation_DuplicateKeyException() {
+        //given
+        SpaceInvitationAcceptRequest request = new SpaceInvitationAcceptRequest(myMember.getId(), myNotification.getId());
+
+        //when//then
+        spaceInvitationFacade.acceptSpaceInvitation(request);
+        assertThatThrownBy(() -> spaceInvitationFacade.acceptSpaceInvitation(request))
+                .isInstanceOf(DuplicateKeyException.class);
     }
 
     private void setUpTestData() {

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
@@ -238,6 +238,26 @@ class DefaultSpaceServiceTest {
     }
 
     @Test
+    @DisplayName("스페이스 멤버들의 권한을 OWNER로 변경할 경우 기존 OWNER는 CAN_EDIT으로 변경 된다.")
+    void changeSpaceMembersRole_changeRoleAsOwner() {
+        //given
+        SpaceMemberRoleChangeRequest request = new SpaceMemberRoleChangeRequest(myFirstSpaceId, myMemberId, anotherMemberId, Role.OWNER);
+
+        //when
+        Long spaceId = spaceService.changeSpaceMembersRole(request);
+
+        //then
+        Space space = spaceJpaRepository.findById(spaceId).get();
+
+        List<SpaceMember> spaceMembers = space.getSortedSpaceMember();
+        assertThat(spaceMembers.size()).isEqualTo(2);
+        assertThat(spaceMembers.get(0).getMemberId()).isEqualTo(anotherMemberId);
+        assertThat(spaceMembers.get(0).getRole()).isEqualTo(Role.OWNER);
+        assertThat(spaceMembers.get(1).getMemberId()).isEqualTo(myMemberId);
+        assertThat(spaceMembers.get(1).getRole()).isEqualTo(Role.CAN_EDIT);
+    }
+
+    @Test
     @DisplayName("스페이스의 오너가 아닌 멤버가 스페이스 멤버의 권한을 변경하려고 하면 UnauthorizedAccessException예외가 발생한다.")
     void changeSpaceMembersRole_UnauthorizedAccessException() {
         //given

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
@@ -248,6 +248,19 @@ class DefaultSpaceServiceTest {
                 .isInstanceOf(UnauthorizedAccessException.class);
     }
 
+    @Test
+    @DisplayName("")
+    void deleteSpaceMemberByMe() {
+        //when
+        spaceService.deleteSpaceMemberByMe(myFirstSpaceId, anotherMemberId);
+
+        //then
+        Space space = spaceJpaRepository.findById(myFirstSpaceId).get();
+        List<SpaceMember> spaceMembers = space.getSpaceMembers();
+
+        assertThat(spaceMembers.size()).isEqualTo(1);
+    }
+
     private void setupData() {
         Member member = new Member(
                 "testSocialId",

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
@@ -233,12 +233,13 @@ class DefaultSpaceServiceTest {
         Space space = spaceJpaRepository.findById(spaceId).get();
 
         List<SpaceMember> spaceMembers = space.getSortedSpaceMember();
+        assertThat(space.getMemberId()).isEqualTo(myMemberId);
         assertThat(spaceMembers.size()).isEqualTo(2);
         assertThat(spaceMembers.get(1).getRole()).isEqualTo(Role.CAN_EDIT);
     }
 
     @Test
-    @DisplayName("스페이스 멤버들의 권한을 OWNER로 변경할 경우 기존 OWNER는 CAN_EDIT으로 변경 된다.")
+    @DisplayName("스페이스 멤버의 권한을 OWNER로 변경할 경우 기존 OWNER는 CAN_EDIT으로 변경 된다.")
     void changeSpaceMembersRole_changeRoleAsOwner() {
         //given
         SpaceMemberRoleChangeRequest request = new SpaceMemberRoleChangeRequest(myFirstSpaceId, myMemberId, anotherMemberId, Role.OWNER);
@@ -250,6 +251,7 @@ class DefaultSpaceServiceTest {
         Space space = spaceJpaRepository.findById(spaceId).get();
 
         List<SpaceMember> spaceMembers = space.getSortedSpaceMember();
+        assertThat(space.getMemberId()).isEqualTo(anotherMemberId);
         assertThat(spaceMembers.size()).isEqualTo(2);
         assertThat(spaceMembers.get(0).getMemberId()).isEqualTo(anotherMemberId);
         assertThat(spaceMembers.get(0).getRole()).isEqualTo(Role.OWNER);

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
@@ -269,7 +269,7 @@ class DefaultSpaceServiceTest {
     }
 
     @Test
-    @DisplayName("")
+    @DisplayName("유저는 자신이 속한 스페이스를 나갈 수 있다.")
     void deleteSpaceMemberByMe() {
         //when
         spaceService.deleteSpaceMemberByMe(myFirstSpaceId, anotherMemberId);
@@ -279,6 +279,14 @@ class DefaultSpaceServiceTest {
         List<SpaceMember> spaceMembers = space.getSpaceMembers();
 
         assertThat(spaceMembers.size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("스페이스의 OWNER는 스페이스 떠나기를 할 경우 IllegalStateException가 발생한다. ")
+    void deleteSpaceMemberByMe_IllegalStateException() {
+        //when//then
+        assertThatThrownBy(() -> spaceService.deleteSpaceMemberByMe(myFirstSpaceId, myMemberId))
+                .isInstanceOf(IllegalStateException.class);
     }
 
     private void setupData() {

--- a/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
@@ -63,6 +63,7 @@ class FavoriteServiceTest {
     @AfterEach
     void tearDown() {
         favoriteJpaRepository.deleteAll();
+        spaceJpaRepository.deleteAll();
     }
 
     @Test


### PR DESCRIPTION
#157 
## 작업한 일
- 스페이스 떠나기 API 구현.
- 해당 API 테스트 작성.
- 스페이스 멤버 추가 시 이미 존재하는지 검증 로직 추가.
- 스페이스 멤버 권한 OWNER로 바꿀 시 기존 OWNER의 권한을 CAN_EDIT으로 변경 로직 추가.
- Space의 SpaceMember, SpaceImage cascade 옵션 변경 및 orphanRemoval 추가.