### PR TITLE
Hotfix/get links,tags - 인기 있는 링크 조회 & 링크 조회 API 수정

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/dto/LinkGetDto.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/dto/LinkGetDto.java
@@ -1,24 +1,9 @@
 package com.tenten.linkhub.domain.space.repository.link.dto;
 
-import com.tenten.linkhub.domain.space.model.link.Color;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.util.List;
 
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
-public class LinkGetDto {
-    private Long linkId;
-    private String title;
-    private String url;
-    private String tagName;
-    private Color tagColor;
-    private Long likeCount;
-    private boolean isLiked;
-    private boolean canLinkSummaraizable;
-    private boolean canReadMark;
-    private List<LinkViewDto> linkViewHistories;
+public record LinkGetDto(
+        LinkInfoDto linkInfoDto,
+        List<LinkViewDto> linkViewHistories
+) {
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/dto/LinkInfoDto.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/dto/LinkInfoDto.java
@@ -1,0 +1,43 @@
+package com.tenten.linkhub.domain.space.repository.link.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.tenten.linkhub.domain.space.model.link.Color;
+
+import java.time.LocalDateTime;
+
+
+public record LinkInfoDto(
+        Long linkId,
+        String title,
+        String url,
+        String tagName,
+        Color tagColor,
+        Long likeCount,
+        boolean isLiked,
+        boolean canLinkSummaraizable,
+        boolean canReadMark,
+        LocalDateTime createdAt
+) {
+    @QueryProjection
+    public LinkInfoDto(Long linkId,
+                       String title,
+                       String url,
+                       String tagName,
+                       Color tagColor,
+                       Long likeCount,
+                       boolean isLiked,
+                       boolean canLinkSummaraizable,
+                       boolean canReadMark,
+                       LocalDateTime createdAt) {
+        this.linkId = linkId;
+        this.title = title;
+        this.url = url;
+        this.tagName = tagName;
+        this.tagColor = tagColor;
+        this.likeCount = likeCount;
+        this.isLiked = isLiked;
+        this.canLinkSummaraizable = canLinkSummaraizable;
+        this.canReadMark = canReadMark;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/dto/LinkViewDto.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/dto/LinkViewDto.java
@@ -1,13 +1,16 @@
 package com.tenten.linkhub.domain.space.repository.link.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
 public class LinkViewDto {
     private String memberName;
     private String memberProfileImage;
+
+    public LinkViewDto(String memberName, String memberProfileImage) {
+        this.memberName = memberName;
+        this.memberProfileImage = memberProfileImage;
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/dto/PopularLinkGetDto.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/dto/PopularLinkGetDto.java
@@ -2,20 +2,17 @@ package com.tenten.linkhub.domain.space.repository.link.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import com.tenten.linkhub.domain.space.model.link.Color;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class PopularLinkGetDto {
-    private Long linkId;
-    private String title;
-    private String url;
-    private String tagName;
-    private Color tagColor;
-    private Long likeCount;
-    private boolean isLiked;
 
+public record PopularLinkGetDto(
+        Long linkId,
+        String title,
+        String url,
+        String tagName,
+        Color tagColor,
+        Long likeCount,
+        boolean isLiked
+) {
     @QueryProjection
     public PopularLinkGetDto(Long linkId, String title, String url, String tagName, Color tagColor, Long likeCount, boolean isLiked) {
         this.linkId = linkId;

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/querydsl/LinkQueryDslRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/querydsl/LinkQueryDslRepository.java
@@ -20,6 +20,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -154,22 +155,29 @@ public class LinkQueryDslRepository {
     }
 
 
-    private OrderSpecifier<String> linkSort(Pageable pageable) {
+    private OrderSpecifier[] linkSort(Pageable pageable) {
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+
         for (Sort.Order sort : pageable.getSort()) {
             String property = sort.getProperty();
 
             switch (property) {
                 case "created_at" -> {
-                    return new OrderSpecifier(Order.DESC, link.createdAt);
+                    orderSpecifiers.add(new OrderSpecifier(Order.DESC, link.createdAt));
+                    orderSpecifiers.add(new OrderSpecifier(Order.DESC, link.id));
+                    return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
                 }
                 case "popular" -> {
-                    return new OrderSpecifier(Order.DESC, link.likeCount);
+                    orderSpecifiers.add(new OrderSpecifier(Order.DESC, link.likeCount));
+                    return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
                 }
             }
         }
 
         // 정렬 조건이 없는 경우 기본적으로 최신순(createdAt 내림차순)으로 정렬
-        return new OrderSpecifier(Order.DESC, link.createdAt);
+        orderSpecifiers.add(new OrderSpecifier(Order.DESC, link.createdAt));
+        orderSpecifiers.add(new OrderSpecifier(Order.DESC, link.id));
+        return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
     }
 
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/link/querydsl/LinkQueryDslRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/link/querydsl/LinkQueryDslRepository.java
@@ -9,8 +9,10 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tenten.linkhub.domain.space.repository.link.dto.LinkGetDto;
 import com.tenten.linkhub.domain.space.repository.link.dto.LinkGetQueryCondition;
+import com.tenten.linkhub.domain.space.repository.link.dto.LinkInfoDto;
 import com.tenten.linkhub.domain.space.repository.link.dto.LinkViewDto;
 import com.tenten.linkhub.domain.space.repository.link.dto.PopularLinkGetDto;
+import com.tenten.linkhub.domain.space.repository.link.dto.QLinkInfoDto;
 import com.tenten.linkhub.domain.space.repository.link.dto.QPopularLinkGetDto;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -19,6 +21,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.querydsl.core.types.dsl.Expressions.TRUE;
 import static com.tenten.linkhub.domain.member.model.QMember.member;
@@ -41,85 +44,97 @@ public class LinkQueryDslRepository {
     }
 
     public Slice<LinkGetDto> getLinksByCondition(LinkGetQueryCondition condition) {
-        List<LinkGetDto> linkGetDtos = jpaQueryFactory
-                .select(link)
+        List<LinkInfoDto> linkInfoDtos = jpaQueryFactory
+                .select(
+                        new QLinkInfoDto(
+                                link.id,
+                                link.title,
+                                link.url.url,
+                                tag.name,
+                                tag.color,
+                                link.likeCount,
+                                isLikedByMember(condition.memberId()),
+                                space.isLinkSummarizable,
+                                space.isReadMarkEnabled,
+                                link.createdAt
+                        )
+                )
                 .from(link)
                 .leftJoin(link.linkTags, linkTag).on(linkTag.isDeleted.eq(false))
                 .leftJoin(linkTag.tag, tag)
                 .leftJoin(link.space, space)
-                .leftJoin(link.linkViewHistories, linkViewHistory)
-                .leftJoin(member).on(linkViewHistory.memberId.eq(member.id))
-                .leftJoin(member.profileImages.profileImageList, profileImage)
-                .leftJoin(like).on(like.link.eq(link))
+                .leftJoin(like).on(like.link.eq(link), isLikedByMember(condition.memberId()))
                 .where(link.space.id.eq(condition.spaceId()))
                 .where(link.isDeleted.eq(Boolean.FALSE))
                 .where(hasTagFilter(condition.tagId()))
                 .orderBy(linkSort(condition.pageable()))
                 .offset(condition.pageable().getOffset())
                 .limit(condition.pageable().getPageSize() + 1)
-                .transform(
-                        GroupBy.groupBy(link.id).list(
-                                Projections.fields(
-                                        LinkGetDto.class,
-                                        link.id.as("linkId"),
-                                        link.title.as("title"),
-                                        link.url.url.as("url"),
-                                        tag.name.as("tagName"),
-                                        tag.color.as("tagColor"),
-                                        link.likeCount.as("likeCount"),
-                                        isLikedByMember(condition.memberId()).as("isLiked"),
-                                        space.isLinkSummarizable.as("canLinkSummaraizable"),
-                                        space.isReadMarkEnabled.as("canReadMark"),
-                                        GroupBy.list(
-                                                Projections.fields(
-                                                        LinkViewDto.class,
-                                                        member.nickname.as("memberName"),
-                                                        profileImage.path.as("memberProfileImage")
-                                                ).skipNulls()
-                                        ).as("linkViewHistories")
-                                )
-                        )
-                );
-
+                .distinct()
+                .fetch();
 
         boolean hasNext = false;
 
-        if (linkGetDtos.size() > condition.pageable().getPageSize()) {
-            linkGetDtos.remove(condition.pageable().getPageSize());
+        if (linkInfoDtos.size() > condition.pageable().getPageSize()) {
+            linkInfoDtos.remove(condition.pageable().getPageSize());
             hasNext = true;
         }
+
+        List<Long> linkIds = linkInfoDtos.stream()
+                .map(LinkInfoDto::linkId) // LinkInfoDto 객체에서 id 필드만 추출
+                .toList();
+
+        Map<Long, List<LinkViewDto>> linkViewDtoMap = jpaQueryFactory
+                .select(link)
+                .from(link)
+                .leftJoin(link.linkViewHistories, linkViewHistory)
+                .leftJoin(member).on(linkViewHistory.memberId.eq(member.id))
+                .leftJoin(member.profileImages.profileImageList, profileImage)
+                .where(link.id.in(linkIds))
+                .transform(GroupBy.groupBy(link.id).as(
+                        GroupBy.list(
+                                Projections.fields(
+                                        LinkViewDto.class,
+                                        member.nickname.as("memberName"),
+                                        profileImage.path.as("memberProfileImage")
+                                ).skipNulls()
+                        )
+
+                ));
+
+
+        // LinkInfoDto와 LinkViewDtoMap을 사용하여 LinkGetDto 생성
+        List<LinkGetDto> linkGetDtos =
+                linkInfoDtos.stream()
+                        .map(linkInfoDto -> new LinkGetDto(linkInfoDto, linkViewDtoMap.get(linkInfoDto.linkId())))
+                        .toList();
 
         return new SliceImpl<>(linkGetDtos, condition.pageable(), hasNext);
     }
 
     public List<PopularLinkGetDto> getPopularLinks(Long memberId) {
-
         return jpaQueryFactory
-                .select(new QPopularLinkGetDto(
-                        link.id,
-                        link.title,
-                        link.url.url,
-                        tag.name,
-                        tag.color,
-                        link.likeCount,
-                        isLikedByMember(memberId)
-                ))
+                .select(
+                        new QPopularLinkGetDto(
+                                link.id,
+                                link.title,
+                                link.url.url,
+                                tag.name,
+                                tag.color,
+                                link.likeCount,
+                                isLikedByMember(memberId)
+                        )
+                )
                 .from(link)
                 .leftJoin(link.space, space)
                 .leftJoin(link.linkTags, linkTag).on(linkTag.isDeleted.eq(false))
                 .leftJoin(linkTag.tag, tag)
-                .leftJoin(like).on(like.link.eq(link))
+                .leftJoin(like).on(like.link.eq(link), isLikedByMember(memberId))
                 .where(link.isDeleted.eq(Boolean.FALSE),
                         space.isDeleted.eq(Boolean.FALSE))
                 .orderBy(link.likeCount.desc())
-//                .groupBy(link.id,
-//                        link.title,
-//                        link.url.url,
-//                        tag.name,
-//                        tag.color,
-//                        link.likeCount,
-//                        like.memberId)
                 .limit(5)
+                .distinct()
                 .fetch();
     }
 

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/LinkGetByQueryResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/LinkGetByQueryResponses.java
@@ -2,6 +2,7 @@ package com.tenten.linkhub.domain.space.service.dto.link;
 
 import com.tenten.linkhub.domain.space.repository.link.dto.LinkGetDto;
 import org.springframework.data.domain.Slice;
+
 import java.util.Objects;
 
 
@@ -11,16 +12,16 @@ public record LinkGetByQueryResponses(
     public static LinkGetByQueryResponses from(Slice<LinkGetDto> linkGetDtos) {
         Slice<LinkGetByQueryResponse> responseList = linkGetDtos
                 .map(dto -> new LinkGetByQueryResponse(
-                        dto.getLinkId(),
-                        dto.getTitle(),
-                        dto.getUrl(),
-                        dto.getTagName(),
-                        Objects.isNull(dto.getTagColor()) ? null : dto.getTagColor().getValue(),
-                        dto.getLikeCount(),
-                        dto.isLiked(),
-                        dto.isCanLinkSummaraizable(),
-                        dto.isCanReadMark(),
-                        dto.getLinkViewHistories()
+                        dto.linkInfoDto().linkId(),
+                        dto.linkInfoDto().title(),
+                        dto.linkInfoDto().url(),
+                        dto.linkInfoDto().tagName(),
+                        Objects.isNull(dto.linkInfoDto().tagColor()) ? null : dto.linkInfoDto().tagColor().getValue(),
+                        dto.linkInfoDto().likeCount(),
+                        dto.linkInfoDto().isLiked(),
+                        dto.linkInfoDto().canLinkSummaraizable(),
+                        dto.linkInfoDto().canReadMark(),
+                        dto.linkViewHistories()
                 ));
 
         return new LinkGetByQueryResponses(responseList);

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/PopularLinksGetByQueryResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/link/PopularLinksGetByQueryResponses.java
@@ -13,12 +13,12 @@ public record PopularLinksGetByQueryResponses(
                 .stream()
                 .map(
                         dto -> new PopularLinksGetByQueryResponse(
-                                dto.getLinkId(),
-                                dto.getTitle(),
-                                dto.getUrl(),
-                                dto.getTagName(),
-                                Objects.isNull(dto.getTagColor()) ? null : dto.getTagColor().getValue(),
-                                dto.getLikeCount(),
+                                dto.linkId(),
+                                dto.title(),
+                                dto.url(),
+                                dto.tagName(),
+                                Objects.isNull(dto.tagColor()) ? null : dto.tagColor().getValue(),
+                                dto.likeCount(),
                                 dto.isLiked()
                         )
                 )

--- a/src/test/java/com/tenten/linkhub/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/notification/service/NotificationServiceTest.java
@@ -16,7 +16,6 @@ import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +46,8 @@ public class NotificationServiceTest {
     @Autowired
     private MemberJpaRepository memberJpaRepository;
 
-    private Long invitingMemberId;
+    private Long invitingMemberId1;
+    private Long invitingMemberId2;
     private Long invitedMemberId;
     private List<Long> spaceIds = new ArrayList<>();
 
@@ -56,14 +56,12 @@ public class NotificationServiceTest {
         setUpTestData();
     }
 
-    @Disabled
     @Test
     @DisplayName("수신한 스페이스 초대 알림을 조회할 수 있다.")
     void getSpaceInvitations_memberId_Success() {
-        //given - 4개의 space에 미리 invitedMember를 초대
-        for (Long spaceId : spaceIds) {
-            spaceInvitationFacade.invite(new SpaceInvitationFacadeRequest("2222@gmail.com", spaceId, Role.CAN_EDIT, invitingMemberId));
-        }
+        //given - 2개의 스페이스에 각각 미리 invitedMember를 초대
+        spaceInvitationFacade.invite(new SpaceInvitationFacadeRequest("invitedMember@gmail.com", spaceIds.get(0), Role.CAN_EDIT, invitingMemberId1));
+        spaceInvitationFacade.invite(new SpaceInvitationFacadeRequest("invitedMember@gmail.com", spaceIds.get(1), Role.CAN_EDIT, invitingMemberId2));
 
         SpaceInviteNotificationGetRequest request = new SpaceInviteNotificationGetRequest(
                 PageRequest.of(0, 10),
@@ -75,13 +73,12 @@ public class NotificationServiceTest {
 
         //then
         assertThat(spaceInvitations.responses().getContent().size()).isEqualTo(spaceIds.size());
-        for (int i = 0; i < spaceIds.size(); i++) {
-            assertThat(spaceInvitations.responses().getContent().get(i).invitingMemberId()).isEqualTo(invitingMemberId);
-        }
+        assertThat(spaceInvitations.responses().getContent().get(0).invitingMemberId()).isEqualTo(invitingMemberId1);
+        assertThat(spaceInvitations.responses().getContent().get(1).invitingMemberId()).isEqualTo(invitingMemberId2);
     }
 
     private void setUpTestData() {
-        Member invitingMember = new Member(
+        Member invitingMember1 = new Member(
                 "123456",
                 Provider.kakao,
                 com.tenten.linkhub.domain.member.model.Role.USER,
@@ -92,37 +89,65 @@ public class NotificationServiceTest {
                 new ProfileImage("https://testprofileimage", "테스트용 멤버 프로필 이미지1"),
                 new FavoriteCategory(Category.ENTER_ART)
         );
+
+        Member invitingMember2 = new Member(
+                "123456",
+                Provider.kakao,
+                com.tenten.linkhub.domain.member.model.Role.USER,
+                "닉네임 데이터",
+                "소개 데이터",
+                "1111@gmail.com",
+                false,
+                new ProfileImage("https://testprofileimage", "테스트용 멤버 프로필 이미지1"),
+                new FavoriteCategory(Category.ENTER_ART)
+        );
+
         Member invitedMember = new Member(
                 "123456",
                 Provider.kakao,
                 com.tenten.linkhub.domain.member.model.Role.USER,
                 "닉네임 데이터1",
                 "소개 데이터1",
-                "2222@gmail.com",
+                "invitedMember@gmail.com",
                 false,
                 new ProfileImage("https://testprofileimage", "테스트용 멤버 프로필 이미지1"),
                 new FavoriteCategory(Category.ENTER_ART)
         );
 
-        invitingMemberId = memberJpaRepository.save(invitingMember).getId();
+        invitingMemberId1 = memberJpaRepository.save(invitingMember1).getId();
+        invitingMemberId2 = memberJpaRepository.save(invitingMember2).getId();
         invitedMemberId = memberJpaRepository.save(invitedMember).getId();
 
         spaceIds.clear();
-        for (int i = 0; i < 4; i++) {
-            Space space = new Space(
-                    invitingMemberId,
-                    "스페이스의 제목",
-                    "스페이스 설명",
-                    Category.ENTER_ART,
-                    new SpaceImage("https://testimage1", "테스트 이미지1"),
-                    new SpaceMember(invitingMemberId, Role.OWNER),
-                    true,
-                    true,
-                    true,
-                    true
-            );
-            spaceJpaRepository.save(space);
-            spaceIds.add(space.getId());
-        }
+        Space space1 = new Space(
+                invitingMemberId1,
+                "스페이스의 제목",
+                "스페이스 설명",
+                Category.ENTER_ART,
+                new SpaceImage("https://testimage1", "테스트 이미지1"),
+                new SpaceMember(invitingMemberId1, Role.OWNER),
+                true,
+                true,
+                true,
+                true
+        );
+        spaceJpaRepository.save(space1);
+        spaceIds.add(space1.getId());
+
+        Space space2 = new Space(
+                invitingMemberId2,
+                "스페이스의 제목",
+                "스페이스 설명",
+                Category.ENTER_ART,
+                new SpaceImage("https://testimage1", "테스트 이미지1"),
+                new SpaceMember(invitingMemberId2, Role.OWNER),
+                true,
+                true,
+                true,
+                true
+        );
+        spaceJpaRepository.save(space2);
+        spaceIds.add(space2.getId());
+
     }
 }


### PR DESCRIPTION
## 📒 구현 내용 📒

### 인기 있는 링크 리스트 조회 API 수정
- 좋아요를 누르더라도 중복하여 조회되지 않도록 코드를 수정했습니다.

### 스페이스 내 링크 리스트 조회 API 수정
- Pagination 정상적으로 작동하도록 수정
- 하나의 쿼리로 조회하던 link의 정보를 2번의 쿼리로 나눠 조회 하도록 수정하였습니다.
1. 링크 정보 조회 : 타이틀, url, 제목, 좋아요 여부, 좋아요 수 등
2. 링크 접속 이력 조회 : 멤버이름, 멤버 프로필 이미지