### PR TITLE
Feature/delete notification - 알림 삭제 기능 구현

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/tenten/linkhub/domain/notification/controller/NotificationController.java
@@ -14,8 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -56,5 +58,18 @@ public class NotificationController {
         return ResponseEntity
                 .ok()
                 .body(apiResponses);
+    }
+
+
+    @DeleteMapping(value = "/{notificationId}")
+    public ResponseEntity<Void> deleteNotification(
+            @PathVariable Long notificationId,
+            @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        notificationService.deleteNotification(notificationId, memberDetails.memberId());
+
+        return ResponseEntity
+                .noContent()
+                .build();
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/tenten/linkhub/domain/notification/controller/NotificationController.java
@@ -60,7 +60,14 @@ public class NotificationController {
                 .body(apiResponses);
     }
 
-
+    /**
+     * 알림 삭제 API
+     */
+    @Operation(
+            summary = "알림 삭제 API ", description = "[JWT 필요] - notificationId를 받아 알림을 삭제해주는 API 입니다. 초대 알림의 경우 초대 내역도 함께 삭제합니다. ",
+            responses = {
+                    @ApiResponse(responseCode = "204", description = "알림 삭제 요청이 성공적으로 완료되었습니다.")
+            })
     @DeleteMapping(value = "/{notificationId}")
     public ResponseEntity<Void> deleteNotification(
             @PathVariable Long notificationId,

--- a/src/main/java/com/tenten/linkhub/domain/notification/repository/DefaultNotificationRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/notification/repository/DefaultNotificationRepository.java
@@ -33,6 +33,11 @@ public class DefaultNotificationRepository implements NotificationRepository {
     }
 
     @Override
+    public void deleteById(Long notificationId, Long memberId) {
+        notificationJpaRepository.deleteById(notificationId, memberId);
+    }
+
+    @Override
     public Slice<SpaceInvitationNotificationGetDto> getInviteNotifications(NotificationGetQueryCondition condition) {
         return notificationQueryDslRepository.getSpaceInvitationNotifications(condition);
     }

--- a/src/main/java/com/tenten/linkhub/domain/notification/repository/DefaultNotificationRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/notification/repository/DefaultNotificationRepository.java
@@ -33,8 +33,8 @@ public class DefaultNotificationRepository implements NotificationRepository {
     }
 
     @Override
-    public void deleteById(Long notificationId, Long memberId) {
-        notificationJpaRepository.deleteById(notificationId, memberId);
+    public void deleteByIdAndRecipientId(Long notificationId, Long memberId) {
+        notificationJpaRepository.deleteByIdAndRecipientId(notificationId, memberId);
     }
 
     @Override

--- a/src/main/java/com/tenten/linkhub/domain/notification/repository/NotificationJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/notification/repository/NotificationJpaRepository.java
@@ -2,8 +2,14 @@ package com.tenten.linkhub.domain.notification.repository;
 
 import com.tenten.linkhub.domain.notification.model.Notification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, Long> {
 
     Boolean existsByRecipientIdAndSenderId(Long recipientId, Long senderId);
+
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE n.id = :notificationId AND n.recipientId = :memberId")
+    void deleteById(Long notificationId, Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/notification/repository/NotificationJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/notification/repository/NotificationJpaRepository.java
@@ -11,5 +11,5 @@ public interface NotificationJpaRepository extends JpaRepository<Notification, L
 
     @Modifying
     @Query("DELETE FROM Notification n WHERE n.id = :notificationId AND n.recipientId = :memberId")
-    void deleteById(Long notificationId, Long memberId);
+    void deleteByIdAndRecipientId(Long notificationId, Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/notification/repository/NotificationRepository.java
@@ -13,4 +13,6 @@ public interface NotificationRepository {
     Notification save(Notification notification);
 
     Boolean existsByMemberIdAndMyMemberId(Long memberId, Long myMemberId);
+
+    void deleteById(Long notificationId, Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/notification/repository/NotificationRepository.java
@@ -14,5 +14,5 @@ public interface NotificationRepository {
 
     Boolean existsByMemberIdAndMyMemberId(Long memberId, Long myMemberId);
 
-    void deleteById(Long notificationId, Long memberId);
+    void deleteByIdAndRecipientId(Long notificationId, Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/tenten/linkhub/domain/notification/service/NotificationService.java
@@ -54,7 +54,7 @@ public class NotificationService {
 
     @Transactional
     public void deleteNotification(Long notificationId, Long memberId) {
-        invitationRepository.deleteByNotificationId(notificationId, memberId);
-        notificationRepository.deleteById(notificationId, memberId);
+        invitationRepository.deleteByNotificationIdAndMemberId(notificationId, memberId);
+        notificationRepository.deleteByIdAndRecipientId(notificationId, memberId);
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/tenten/linkhub/domain/notification/service/NotificationService.java
@@ -8,6 +8,7 @@ import com.tenten.linkhub.domain.notification.service.dto.NotificationCreateRequ
 import com.tenten.linkhub.domain.notification.service.dto.SpaceInviteNotificationGetRequest;
 import com.tenten.linkhub.domain.notification.service.dto.SpaceInviteNotificationGetResponses;
 import com.tenten.linkhub.domain.notification.service.mapper.NotificationMapper;
+import com.tenten.linkhub.domain.space.repository.invitation.InvitationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -20,6 +21,7 @@ public class NotificationService {
 
     private final NotificationRepository notificationRepository;
     private final NotificationMapper notificationMapper;
+    private final InvitationRepository invitationRepository;
 
     @Transactional
     public void changeIsCheckedAsTrue(Long notificationId, Long memberId) {
@@ -48,5 +50,11 @@ public class NotificationService {
 
     public Boolean existsByMemberIdAndMyMemberId(Long memberId, Long myMemberId) {
         return notificationRepository.existsByMemberIdAndMyMemberId(memberId, myMemberId);
+    }
+
+    @Transactional
+    public void deleteNotification(Long notificationId, Long memberId) {
+        invitationRepository.deleteByNotificationId(notificationId, memberId);
+        notificationRepository.deleteById(notificationId, memberId);
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/invitation/DefaultInvitationRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/invitation/DefaultInvitationRepository.java
@@ -23,7 +23,7 @@ public class DefaultInvitationRepository implements InvitationRepository {
     }
 
     @Override
-    public void deleteByNotificationId(Long notificationId, Long memberId) {
+    public void deleteByNotificationIdAndMemberId(Long notificationId, Long memberId) {
         invitationJpaRepository.deleteByNotificationId(notificationId, memberId);
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/invitation/DefaultInvitationRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/invitation/DefaultInvitationRepository.java
@@ -21,4 +21,9 @@ public class DefaultInvitationRepository implements InvitationRepository {
     public Invitation save(Invitation invitation) {
         return invitationJpaRepository.save(invitation);
     }
+
+    @Override
+    public void deleteByNotificationId(Long notificationId, Long memberId) {
+        invitationJpaRepository.deleteByNotificationId(notificationId, memberId);
+    }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/invitation/InvitationJpaRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/invitation/InvitationJpaRepository.java
@@ -2,9 +2,15 @@ package com.tenten.linkhub.domain.space.repository.invitation;
 
 import com.tenten.linkhub.domain.space.model.space.Invitation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface InvitationJpaRepository extends JpaRepository<Invitation, Long> {
     Optional<Invitation> findByNotificationId(Long notificationId);
+
+    @Modifying
+    @Query("DELETE FROM Invitation i WHERE i.notificationId = :notificationId AND i.memberId = :memberId")
+    void deleteByNotificationId(Long notificationId, Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/invitation/InvitationRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/invitation/InvitationRepository.java
@@ -6,4 +6,6 @@ public interface InvitationRepository {
     Invitation getByNotificationId(Long notificationId);
 
     Invitation save(Invitation invitation);
+
+    void deleteByNotificationId(Long notificationId, Long memberId);
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/invitation/InvitationRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/invitation/InvitationRepository.java
@@ -7,5 +7,5 @@ public interface InvitationRepository {
 
     Invitation save(Invitation invitation);
 
-    void deleteByNotificationId(Long notificationId, Long memberId);
+    void deleteByNotificationIdAndMemberId(Long notificationId, Long memberId);
 }

--- a/src/test/java/com/tenten/linkhub/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/notification/service/NotificationServiceTest.java
@@ -77,6 +77,25 @@ public class NotificationServiceTest {
         assertThat(spaceInvitations.responses().getContent().get(1).invitingMemberId()).isEqualTo(invitingMemberId2);
     }
 
+    @Test
+    @DisplayName("사용자는 알림 내역을 삭제할 수 있다.")
+    void deleteNotification_notificationIdAndMemberId_Success() {
+        //given
+        Long inviteNotificationId = spaceInvitationFacade.invite(new SpaceInvitationFacadeRequest("invitedMember@gmail.com", spaceIds.get(0), Role.CAN_EDIT, invitingMemberId1));
+
+        //when
+        notificationService.deleteNotification(inviteNotificationId, invitedMemberId);
+
+        //then
+        SpaceInviteNotificationGetRequest request = new SpaceInviteNotificationGetRequest(
+                PageRequest.of(0, 10),
+                invitedMemberId
+        );
+        SpaceInviteNotificationGetResponses spaceInvitations = notificationService.getSpaceInvitations(request);
+
+        assertThat(spaceInvitations.responses().getContent().size()).isEqualTo(0);
+    }
+
     private void setUpTestData() {
         Member invitingMember1 = new Member(
                 "123456",


### PR DESCRIPTION
## 🔗 Issue 🔗
#167 

## 📒 구현 내용 📒
### 초대 알림 삭제 기능 구현
- 초대 알림 삭제 기능을 구현했습니다.
- 초대 알림을 삭제할 경우 초대 내역까지 함께 삭제하도록 구현했습니다.(즉, 초대 알림을 삭제할 경우 초대 내역도 사라져 다시 초대 신청 가능하도록 했습니다.)
- 테스트코드를 작성했습니다.
- Swagger 문서화를 완료했습니다.
