### PR TITLE
[Fix]: Integration 서비스 테스트 시 `@MockBean`으로 인한 테스트 속도 저하 문제 해결.

### DIFF
--- a/src/test/java/com/tenten/linkhub/IntegrationApplicationTest.java
+++ b/src/test/java/com/tenten/linkhub/IntegrationApplicationTest.java
@@ -1,0 +1,15 @@
+package com.tenten.linkhub;
+
+import com.tenten.linkhub.global.aws.s3.ImageFileUploader;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public abstract class IntegrationApplicationTest {
+
+    @MockBean
+    protected ImageFileUploader mockImageFileUploader;
+
+}

--- a/src/test/java/com/tenten/linkhub/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.member.service;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.auth.JwtProvider;
 import com.tenten.linkhub.domain.auth.MemberDetails;
 import com.tenten.linkhub.domain.member.model.Member;
@@ -21,7 +22,6 @@ import com.tenten.linkhub.domain.member.service.dto.MemberUpdateRequest;
 import com.tenten.linkhub.domain.member.service.dto.MemberUpdateResponse;
 import com.tenten.linkhub.domain.space.model.category.Category;
 import com.tenten.linkhub.global.aws.dto.ImageInfo;
-import com.tenten.linkhub.global.aws.s3.ImageFileUploader;
 import com.tenten.linkhub.global.exception.DataDuplicateException;
 import com.tenten.linkhub.global.exception.DataNotFoundException;
 import org.assertj.core.api.Assertions;
@@ -31,12 +31,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.core.Authentication;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -45,19 +42,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 
-@SpringBootTest
 @Transactional
-@ActiveProfiles("test")
-class MemberServiceTest {
+class MemberServiceTest extends IntegrationApplicationTest {
 
     @Autowired
     private MemberService memberService;
 
     @Autowired
     private MemberEmailRedisRepository redisRepository;
-
-    @MockBean
-    private ImageFileUploader mockImageFileUploader;
 
     @Autowired
     private JwtProvider jwtProvider;

--- a/src/test/java/com/tenten/linkhub/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/notification/service/NotificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.notification.service;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
@@ -20,9 +21,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -30,10 +29,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("test")
-@SpringBootTest
 @Transactional
-public class NotificationServiceTest {
+public class NotificationServiceTest extends IntegrationApplicationTest {
 
     @Autowired
     private NotificationService notificationService;

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/CommentFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/CommentFacadeTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.facade;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
@@ -22,9 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -32,10 +31,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ActiveProfiles("test")
 @Transactional
-@SpringBootTest
-class CommentFacadeTest {
+class CommentFacadeTest extends IntegrationApplicationTest {
 
     @Autowired
     private CommentFacade commentFacade;

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/LinkFacadeTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.facade;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
@@ -28,19 +29,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("test")
 @Transactional
-@SpringBootTest
-class LinkFacadeTest {
+class LinkFacadeTest extends IntegrationApplicationTest {
 
     @Autowired
     private LinkFacade linkFacade;

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/SpaceFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/SpaceFacadeTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.facade;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
@@ -23,10 +24,8 @@ import com.tenten.linkhub.domain.space.repository.link.LinkJpaRepository;
 import com.tenten.linkhub.domain.space.repository.scrap.ScrapRepository;
 import com.tenten.linkhub.domain.space.repository.space.SpaceJpaRepository;
 import com.tenten.linkhub.domain.space.service.LinkService;
-import com.tenten.linkhub.domain.space.service.SpaceService;
 import com.tenten.linkhub.domain.space.service.dto.link.LinkCreateRequest;
 import com.tenten.linkhub.global.aws.dto.ImageInfo;
-import com.tenten.linkhub.global.aws.s3.ImageFileUploader;
 import com.tenten.linkhub.global.exception.PolicyViolationException;
 import com.tenten.linkhub.global.exception.UnauthorizedAccessException;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,10 +33,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
@@ -48,10 +44,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 
-@ActiveProfiles("test")
 @Transactional
-@SpringBootTest
-class SpaceFacadeTest {
+class SpaceFacadeTest extends IntegrationApplicationTest {
 
     @Autowired
     private SpaceFacade spaceFacade;
@@ -73,9 +67,6 @@ class SpaceFacadeTest {
 
     @Autowired
     private ScrapRepository scrapRepository;
-
-    @MockBean
-    private ImageFileUploader mockImageFileUploader;
 
     private Long myMemberId;
     private Long anotherMemberId;

--- a/src/test/java/com/tenten/linkhub/domain/space/facade/SpaceInvitationFacadeTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/facade/SpaceInvitationFacadeTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.facade;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
@@ -24,17 +25,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ActiveProfiles("test")
 @Transactional
-@SpringBootTest
-class SpaceInvitationFacadeTest {
+class SpaceInvitationFacadeTest extends IntegrationApplicationTest {
 
     @Autowired
     private SpaceInvitationFacade spaceInvitationFacade;

--- a/src/test/java/com/tenten/linkhub/domain/space/service/CommentServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/CommentServiceTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
@@ -22,8 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
@@ -31,10 +30,8 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ActiveProfiles("test")
 @Transactional
-@SpringBootTest
-class CommentServiceTest {
+class CommentServiceTest extends IntegrationApplicationTest {
 
     @Autowired
     private CommentService commentService;
@@ -251,7 +248,7 @@ class CommentServiceTest {
                 .isInstanceOf(DataNotFoundException.class);
     }
 
-    private void setUpTestData(){
+    private void setUpTestData() {
         Member member1 = new Member(
                 "testSocialId",
                 Provider.kakao,
@@ -297,7 +294,7 @@ class CommentServiceTest {
                 "두번째 스페이스",
                 "두번째 스페이스 소개글",
                 Category.ETC,
-                new SpaceImage( "https://testimage2", "테스트 이미지2"),
+                new SpaceImage("https://testimage2", "테스트 이미지2"),
                 new SpaceMember(setUpMemberId1, Role.OWNER),
                 true,
                 false,

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultLinkServiceTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
@@ -25,20 +26,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@ActiveProfiles("test")
-@SpringBootTest
 @Transactional
-class DefaultLinkServiceTest {
+class DefaultLinkServiceTest extends IntegrationApplicationTest {
 
     @Autowired
     private LinkService linkService;

--- a/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/DefaultSpaceServiceTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
@@ -26,10 +27,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -37,10 +36,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ActiveProfiles("test")
 @Transactional
-@SpringBootTest
-class DefaultSpaceServiceTest {
+class DefaultSpaceServiceTest extends IntegrationApplicationTest {
 
     @Autowired
     private SpaceService spaceService;

--- a/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/FavoriteServiceTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
@@ -23,9 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -35,9 +34,7 @@ import java.util.concurrent.Executors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@ActiveProfiles("test")
-@SpringBootTest
-class FavoriteServiceTest {
+class FavoriteServiceTest extends IntegrationApplicationTest {
 
     @Autowired
     private FavoriteService favoriteService;

--- a/src/test/java/com/tenten/linkhub/domain/space/service/LikeServiceTest.java
+++ b/src/test/java/com/tenten/linkhub/domain/space/service/LikeServiceTest.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.IntegrationApplicationTest;
 import com.tenten.linkhub.domain.member.model.FavoriteCategory;
 import com.tenten.linkhub.domain.member.model.Member;
 import com.tenten.linkhub.domain.member.model.ProfileImage;
@@ -20,8 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
@@ -31,11 +30,9 @@ import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-@ActiveProfiles("test")
 @Slf4j
 @Sql(scripts = "/sql/clean_up.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
-public class LikeServiceTest {
+public class LikeServiceTest extends IntegrationApplicationTest {
     private static int THREAD_COUNT = 100;
 
     @Autowired


### PR DESCRIPTION
## 작업한 일
- 현재 `@SpringBootTest`가 달려있는 Integration 서비스 테스트 시 `@MockBeen`의 여부에 따라 캐싱된 ApplicationContext를 이용하지 않고 새로 띄우는 문제로 인한 테스트 속도 저하문제 해결.
  - 추상 클래스를 만들고 해당 추상 클래스에 외부 API인 이미지 업로드 클래스를 `@MockBeen`으로 선언 후 상속받는 방식을 통해 해결.