### PR TITLE
[Fix]: db 스키마 파일중 rds권한 오류를 유발하는 부분 제거.

### DIFF
--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -16,11 +16,8 @@ create table spaces
     scrap_count          bigint                                                                                               not null,
     space_name           varchar(255)                                                                                         not null,
     view_count           bigint                                                                                               not null,
-    FULLTEXT INDEX `ft_space_name` (`space_name`) WITH PARSER `ngram`
-                                                      )
-    ENGINE=InnoDB
-    DEFAULT CHARACTER SET = utf8;
-SET GLOBAL innodb_ft_enable_stopword = 0;
+    FULLTEXT INDEX `ft_space_name` (`space_name`) WITH PARSER `ngram`)
+    ENGINE=InnoDB;
 
 create table members
 (


### PR DESCRIPTION
'SET GLOBAL innodb_ft_enable_stopword = 0' 제거.