### PR TITLE
[Refactor]: 메인페이지용 스페이스 필터조회 쿼리 left join으로 변경.

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/querydsl/SpaceQueryDslRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/querydsl/SpaceQueryDslRepository.java
@@ -37,7 +37,7 @@ public class SpaceQueryDslRepository {
                         member.nickname
                 ))
                 .from(space)
-                .join(member).on(space.memberId.eq(member.id))
+                .leftJoin(member).on(space.memberId.eq(member.id))
                 .where(space.isDeleted.eq(false),
                         space.isVisible.eq(true),
                         dynamicQueryFactory.eqSpaceName(condition.keyWord()),


### PR DESCRIPTION
## 작업한 일
- 스페이스 페이지네이션 조회들 및 특정 유저 스페이스 조회 쿼리들을 최적화 하였습니다.
  - 해당 쿼리의 실행 계획을 확인해본 결과 Extra에 Using where; Using temporary; Using filesort 출력. 즉 임시 테이블 생성 후 정렬로 인한 슬로우 쿼리 발생.
  - 원인은 Using where; Using join buffer (hash join) 즉 조인 버퍼를 이용한 해시조인이 원인으로 optimizer_switch 시스템 변수를 조정하여 강제로 nested loop 조인을 사용하게 하니 정상적으로 인덱스 정렬 수행하는 것을 확인.
  - 해시 조인이 사용되었던 것은 join의 드리븐 테이블인 members 테이블의 데이터 분포 때문(데이터가 너무 적어서) 데이터를 추가로 몇 건 더 넣어 보니 nested loop로 동작 확인.
  - 하지만 양 테이블 다 조인 조건의 컬럼에 인덱스가 존재할 예정이기에(spaces 같은 경우 특정 멤버의 스페이스 조회때문에 생성할 확률이 높음)옵티마이저에 의해 추후 드라이빙 테이블이 spaces가 아닌 members로 바뀔경우 해당 문제가 또다시 일어나기에 inner join에서 left join으로 변경하였습니다.
  - spaces 100만건 데이터 기준 1908ms → 83ms