### PR TITLE
Refactor/space/pagination  - 메인페이지용 스페이스 필터 조회 API cursor-based pagination 방식으로 변경.

### DIFF
--- a/src/main/java/com/tenten/linkhub/domain/space/common/CursorPageMataData.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/common/CursorPageMataData.java
@@ -1,0 +1,9 @@
+package com.tenten.linkhub.domain.space.common;
+
+public record CursorPageMataData(
+        Long lastFavoriteCount,
+        Long lastId,
+        Integer pageSize,
+        Boolean hasNext
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/common/SpaceCursorPageRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/common/SpaceCursorPageRequest.java
@@ -1,0 +1,25 @@
+package com.tenten.linkhub.domain.space.common;
+
+import com.tenten.linkhub.domain.space.model.category.Category;
+import org.springframework.data.domain.Sort;
+import org.springframework.util.StringUtils;
+
+public record SpaceCursorPageRequest(
+        Integer pageSize,
+        Sort sort,
+        Category filter
+) {
+
+    public static SpaceCursorPageRequest of(
+            Integer pageSize,
+            String sort,
+            Category filter
+            )
+    {
+        return new SpaceCursorPageRequest(
+                pageSize,
+                StringUtils.hasText(sort) ? Sort.by(sort) : Sort.unsorted(),
+                filter);
+    }
+
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/common/SpaceCursorSlice.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/common/SpaceCursorSlice.java
@@ -1,0 +1,49 @@
+package com.tenten.linkhub.domain.space.common;
+
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Getter
+public class SpaceCursorSlice<T> {
+    private final Long lastFavoriteCount;
+    private final Long lastId;
+    private final Integer pageSize;
+    private final Boolean hasNext;
+    private final List<T> content;
+
+    public SpaceCursorSlice(Long lastFavoriteCount, Long lastId, Integer pageSize, Boolean hasNext, List<T> content) {
+        this.lastFavoriteCount = lastFavoriteCount;
+        this.lastId = lastId;
+        this.pageSize = pageSize;
+        this.hasNext = hasNext;
+        this.content = new ArrayList<>(content);
+    }
+
+    public static <T> SpaceCursorSlice<T> of(Long lastFavoriteCount, Long lastId, Integer pageSize, Boolean hasNext, List<T> content) {
+        return new SpaceCursorSlice<>(
+                lastFavoriteCount,
+                lastId,
+                pageSize,
+                hasNext,
+                content
+        );
+    }
+
+    public <U> SpaceCursorSlice<U> map(Function<? super T, ? extends U> converter) {
+        List<U> newContent = content.stream()
+                .map(converter)
+                .collect(Collectors.toList());
+        return new SpaceCursorSlice<>(
+                lastFavoriteCount,
+                lastId,
+                pageSize,
+                hasNext,
+                newContent
+        );
+    }
+
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
@@ -283,11 +283,12 @@ public class SpaceController {
      * 스페이스 필터 조회 API
      */
     @Operation(
-            summary = "스페이스 필터 조회 API", description = "메인 페이지용 스페이스 필터 조회이며 pageNumber, pageSize, sort, filter를 받아 검색합니다. (sort, filter조건 없이 사용 가능합니다.)\n\n " +
-            "sort: {created_at, updated_at, favorite_count, view_count}\n\n " +
+            summary = "스페이스 필터 조회 API", description = "메인 페이지용 스페이스 필터 조회이며 lastSpaceId(정렬 조건 favorite_count인 경우 lastFavoriteCount 추가로 필요), pageSize, sort, filter를 받아 조회합니다. (sort, filter조건 없이 사용 가능합니다.)\n\n " +
+            "첫 페이지 조회의 경우 lastSpaceId 없이 요청하면 됩니다. (정렬 조건 favorite_count의 경우 lastSpaceId, lastFavoriteCount 둘다 없이 요청.)\n\n " +
+            "sort: {created_at, favorite_count}\n\n " +
             "filter: {ENTER_ART, LIFE_KNOWHOW_SHOPPING, HOBBY_LEISURE_TRAVEL, KNOWLEDGE_ISSUE_CAREER, ETC}",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "검색이 성공적으로 완료 되었습니다."),
+                    @ApiResponse(responseCode = "200", description = "조회가 성공적으로 완료 되었습니다."),
             })
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PublicSpaceFindWithFilterApiResponses> findPublicSpacesWithFilter(

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
@@ -129,7 +129,7 @@ public class SpaceController {
                 request.pageSize(),
                 StringUtils.hasText(request.sort()) ? Sort.by(request.sort()) : Sort.unsorted());
 
-        SpacesFindByQueryResponses responses = spaceService.findPublicSpacesByQuery(
+        SpacesFindByQueryResponses responses = spaceService.searchPublicSpacesByQuery(
                 spaceMapper.toPublicSpacesFindByQueryRequest(request, pageRequest)
         );
 

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/SpaceController.java
@@ -2,6 +2,7 @@ package com.tenten.linkhub.domain.space.controller;
 
 import com.tenten.linkhub.domain.auth.MemberDetails;
 
+import com.tenten.linkhub.domain.space.common.SpaceCursorPageRequest;
 import com.tenten.linkhub.domain.space.controller.dto.comment.CommentUpdateApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.comment.CommentUpdateApiResponse;
 import com.tenten.linkhub.domain.space.controller.dto.comment.RepliesFindApiRequest;
@@ -48,10 +49,11 @@ import com.tenten.linkhub.domain.space.service.dto.comment.ReplyCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.comment.RootCommentCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.favorite.FavoriteSpacesFindResponses;
 import com.tenten.linkhub.domain.space.service.dto.favorite.SpaceRegisterInFavoriteResponse;
-import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindWithFilterRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryResponses;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagGetResponses;
 
+import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindWithCursorResponses;
 import com.tenten.linkhub.global.response.ErrorResponse;
 import com.tenten.linkhub.global.response.ErrorWithDetailCodeResponse;
 
@@ -291,13 +293,13 @@ public class SpaceController {
     public ResponseEntity<PublicSpaceFindWithFilterApiResponses> findPublicSpacesWithFilter(
             @ModelAttribute PublicSpacesFindWithFilterApiRequest request
     ) {
-        PageRequest pageRequest = PageRequest.of(
-                request.pageNumber(),
+        SpaceCursorPageRequest pageRequest = SpaceCursorPageRequest.of(
                 request.pageSize(),
-                StringUtils.hasText(request.sort()) ? Sort.by(request.sort()) : Sort.unsorted());
+                request.sort(),
+                request.filter());
 
-        PublicSpacesFindByQueryRequest serviceRequest = spaceMapper.toPublicSpacesFindByQueryRequest(request, pageRequest);
-        SpacesFindByQueryResponses responses = spaceService.findPublicSpacesByQuery(serviceRequest);
+        PublicSpacesFindWithFilterRequest serviceRequest = spaceMapper.toPublicSpacesFindWithFilterRequest(request, pageRequest);
+        SpacesFindWithCursorResponses responses = spaceService.findPublicSpacesWithFilter(serviceRequest);
 
         PublicSpaceFindWithFilterApiResponses apiResponses = PublicSpaceFindWithFilterApiResponses.from(responses);
 

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/space/PublicSpaceFindWithFilterApiResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/space/PublicSpaceFindWithFilterApiResponses.java
@@ -1,17 +1,17 @@
 package com.tenten.linkhub.domain.space.controller.dto.space;
 
-import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryResponses;
-import com.tenten.linkhub.global.util.PageMetaData;
-import org.springframework.data.domain.Slice;
+import com.tenten.linkhub.domain.space.common.CursorPageMataData;
+import com.tenten.linkhub.domain.space.common.SpaceCursorSlice;
+import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindWithCursorResponses;
 
 import java.util.List;
 
 public record PublicSpaceFindWithFilterApiResponses(
         List<PublicSpaceFindWithFilterApiResponse> responses,
-        PageMetaData metaData
+        CursorPageMataData metaData
 ) {
-    public static PublicSpaceFindWithFilterApiResponses from(SpacesFindByQueryResponses responses) {
-        Slice<PublicSpaceFindWithFilterApiResponse> mapResponses = responses.responses()
+    public static PublicSpaceFindWithFilterApiResponses from(SpacesFindWithCursorResponses responses) {
+        SpaceCursorSlice<PublicSpaceFindWithFilterApiResponse> mapResponses = responses.responses()
                 .map(r -> new PublicSpaceFindWithFilterApiResponse(
                         r.spaceId(),
                         r.spaceName(),
@@ -23,13 +23,15 @@ public record PublicSpaceFindWithFilterApiResponses(
                         r.spaceImagePath(),
                         r.ownerNickName()));
 
-        PageMetaData pageMetaData = new PageMetaData(
-                mapResponses.hasNext(),
-                mapResponses.getSize(),
-                mapResponses.getNumber());
+        CursorPageMataData cursorPageMataData = new CursorPageMataData(
+                mapResponses.getLastFavoriteCount(),
+                mapResponses.getLastId(),
+                mapResponses.getPageSize(),
+                mapResponses.getHasNext()
+        );
 
         return new PublicSpaceFindWithFilterApiResponses(
                 mapResponses.getContent(),
-                pageMetaData);
+                cursorPageMataData);
     }
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/dto/space/PublicSpacesFindWithFilterApiRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/dto/space/PublicSpacesFindWithFilterApiRequest.java
@@ -4,8 +4,11 @@ import com.tenten.linkhub.domain.space.model.category.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record PublicSpacesFindWithFilterApiRequest(
-        @Schema(title = "페이지 번호", example = "0")
-        Integer pageNumber,
+        @Schema(title = "마지막 favoriteCount", example = "1")
+        Long lastFavoriteCount,
+
+        @Schema(title = "마지막 spaceId", example = "1")
+        Long lastSpaceId,
 
         @Schema(title = "페이지 크기", example = "10")
         Integer pageSize,

--- a/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/SpaceApiMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/controller/mapper/SpaceApiMapper.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.controller.mapper;
 
+import com.tenten.linkhub.domain.space.common.SpaceCursorPageRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.NewSpacesScrapApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.PublicSpacesFindWithFilterApiRequest;
 import com.tenten.linkhub.domain.space.controller.dto.space.SpaceCreateApiRequest;
@@ -11,6 +12,7 @@ import com.tenten.linkhub.domain.space.facade.dto.NewSpacesScrapFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.dto.SpaceCreateFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.dto.SpaceDetailGetByIdFacadeRequest;
 import com.tenten.linkhub.domain.space.facade.dto.SpaceUpdateFacadeRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindWithFilterRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagGetResponses;
 import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryRequest;
 import com.tenten.linkhub.domain.space.service.dto.spacemember.SpaceMemberRoleChangeRequest;
@@ -28,7 +30,7 @@ public interface SpaceApiMapper {
 
     PublicSpacesFindByQueryRequest toPublicSpacesFindByQueryRequest(PublicSpacesFindByQueryApiRequest request, Pageable pageable);
 
-    PublicSpacesFindByQueryRequest toPublicSpacesFindByQueryRequest(PublicSpacesFindWithFilterApiRequest request, Pageable pageable);
+    PublicSpacesFindWithFilterRequest toPublicSpacesFindWithFilterRequest(PublicSpacesFindWithFilterApiRequest request, SpaceCursorPageRequest pageable);
 
     SpaceCreateFacadeRequest toSpaceCreateFacadeRequest(SpaceCreateApiRequest request, MultipartFile file, Long memberId);
 

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/common/mapper/RepositoryDtoMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/common/mapper/RepositoryDtoMapper.java
@@ -1,22 +1,25 @@
-package com.tenten.linkhub.domain.space.repository.common.dto;
+package com.tenten.linkhub.domain.space.repository.common.mapper;
 
 import com.tenten.linkhub.domain.space.model.space.SpaceImage;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public record SpaceAndSpaceImageOwnerNickNames(
-        List<SpaceAndSpaceImageOwnerNickName> contents
-) {
-    public static SpaceAndSpaceImageOwnerNickNames of(List<SpaceAndOwnerNickName> spaceAndOwnerNickNames, List<SpaceImage> spaceImages) {
+@Component
+public class RepositoryDtoMapper {
+
+    public List<SpaceAndSpaceImageOwnerNickName> toSpaceAndSpaceImageOwnerNickNames(List<SpaceAndOwnerNickName> spaceAndOwnerNickNames, List<SpaceImage> spaceImages) {
         Map<Long, List<SpaceImage>> spaceImageMap = spaceImages
                 .stream()
                 .collect(Collectors.groupingBy(
                         si -> si.getSpace().getId()
                 ));
 
-        List<SpaceAndSpaceImageOwnerNickName> mapSpaceAndSpaceImageOwnerNickNames = spaceAndOwnerNickNames
+        return spaceAndOwnerNickNames
                 .stream()
                 .map(so -> new SpaceAndSpaceImageOwnerNickName(
                         so.space(),
@@ -24,7 +27,6 @@ public record SpaceAndSpaceImageOwnerNickNames(
                         so.ownerNickName()
                 ))
                 .collect(Collectors.toList());
-
-        return new SpaceAndSpaceImageOwnerNickNames(mapSpaceAndSpaceImageOwnerNickNames);
     }
+
 }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/favorite/querydsl/FavoriteQueryDslRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/favorite/querydsl/FavoriteQueryDslRepository.java
@@ -7,8 +7,9 @@ import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.repository.common.dto.QSpaceAndOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
-import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickNames;
+import com.tenten.linkhub.domain.space.repository.common.mapper.RepositoryDtoMapper;
 import com.tenten.linkhub.domain.space.repository.favorite.dto.MyFavoriteSpacesQueryCondition;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
@@ -21,14 +22,12 @@ import static com.tenten.linkhub.domain.member.model.QMember.member;
 import static com.tenten.linkhub.domain.space.model.space.QFavorite.favorite;
 import static com.tenten.linkhub.domain.space.model.space.QSpaceImage.spaceImage;
 
+@RequiredArgsConstructor
 @Repository
 public class FavoriteQueryDslRepository {
 
     private final JPAQueryFactory queryFactory;
-
-    public FavoriteQueryDslRepository(JPAQueryFactory queryFactory) {
-        this.queryFactory = queryFactory;
-    }
+    private final RepositoryDtoMapper mapper;
 
     public Slice<SpaceAndSpaceImageOwnerNickName> findMyFavoriteSpacesByQuery(MyFavoriteSpacesQueryCondition condition) {
         List<SpaceAndOwnerNickName> spaceAndOwnerNickNames = queryFactory
@@ -52,9 +51,7 @@ public class FavoriteQueryDslRepository {
         List<Long> spaceIds = getSpaceIds(spaceAndOwnerNickNames);
         List<SpaceImage> spaceImages = findSpaceImagesBySpaceIds(spaceIds);
 
-        SpaceAndSpaceImageOwnerNickNames spaceAndSpaceImageOwnerNickNames = SpaceAndSpaceImageOwnerNickNames.of(spaceAndOwnerNickNames, spaceImages);
-
-        List<SpaceAndSpaceImageOwnerNickName> contents = spaceAndSpaceImageOwnerNickNames.contents();
+        List<SpaceAndSpaceImageOwnerNickName> contents = mapper.toSpaceAndSpaceImageOwnerNickNames(spaceAndOwnerNickNames, spaceImages);
         boolean hasNext = false;
 
         if (contents.size() > condition.pageable().getPageSize()) {

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/DefaultSpaceRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/DefaultSpaceRepository.java
@@ -1,7 +1,9 @@
 package com.tenten.linkhub.domain.space.repository.space;
 
+import com.tenten.linkhub.domain.space.common.SpaceCursorSlice;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.space.dto.CursorPageQueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.dto.MemberSpacesQueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.dto.QueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.querydsl.SpaceQueryDslRepository;
@@ -22,7 +24,7 @@ public class DefaultSpaceRepository implements SpaceRepository {
     }
 
     @Override
-    public Slice<SpaceAndSpaceImageOwnerNickName> findPublicSpacesJoinSpaceImageByQuery(QueryCondition queryCondition) {
+    public SpaceCursorSlice<SpaceAndSpaceImageOwnerNickName> findPublicSpacesJoinSpaceImageByQuery(CursorPageQueryCondition queryCondition) {
         return spaceQueryDslRepository.findPublicSpacesJoinSpaceImageByCondition(queryCondition);
     }
 

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/DefaultSpaceRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/DefaultSpaceRepository.java
@@ -27,6 +27,11 @@ public class DefaultSpaceRepository implements SpaceRepository {
     }
 
     @Override
+    public Slice<SpaceAndSpaceImageOwnerNickName> searchPublicSpacesJoinSpaceImageByQuery(QueryCondition queryCondition) {
+        return spaceQueryDslRepository.searchPublicSpacesJoinSpaceImageByCondition(queryCondition);
+    }
+
+    @Override
     public Space save(Space space) {
         return spaceJpaRepository.save(space);
     }

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/SpaceRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/SpaceRepository.java
@@ -10,6 +10,8 @@ public interface SpaceRepository {
 
     Slice<SpaceAndSpaceImageOwnerNickName> findPublicSpacesJoinSpaceImageByQuery(QueryCondition queryCondition);
 
+    Slice<SpaceAndSpaceImageOwnerNickName> searchPublicSpacesJoinSpaceImageByQuery(QueryCondition queryCondition);
+
     Space save(Space space);
 
     Space getById(Long spaceId);

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/SpaceRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/SpaceRepository.java
@@ -1,14 +1,16 @@
 package com.tenten.linkhub.domain.space.repository.space;
 
+import com.tenten.linkhub.domain.space.common.SpaceCursorSlice;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
+import com.tenten.linkhub.domain.space.repository.space.dto.CursorPageQueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.dto.MemberSpacesQueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.dto.QueryCondition;
 import org.springframework.data.domain.Slice;
 
 public interface SpaceRepository {
 
-    Slice<SpaceAndSpaceImageOwnerNickName> findPublicSpacesJoinSpaceImageByQuery(QueryCondition queryCondition);
+    SpaceCursorSlice<SpaceAndSpaceImageOwnerNickName> findPublicSpacesJoinSpaceImageByQuery(CursorPageQueryCondition queryCondition);
 
     Slice<SpaceAndSpaceImageOwnerNickName> searchPublicSpacesJoinSpaceImageByQuery(QueryCondition queryCondition);
 

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/dto/CursorPageQueryCondition.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/dto/CursorPageQueryCondition.java
@@ -1,0 +1,10 @@
+package com.tenten.linkhub.domain.space.repository.space.dto;
+
+import com.tenten.linkhub.domain.space.common.SpaceCursorPageRequest;
+
+public record CursorPageQueryCondition(
+        SpaceCursorPageRequest pageable,
+        Long lastFavoriteCount,
+        Long lastSpaceId
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/querydsl/DynamicQueryFactory.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/querydsl/DynamicQueryFactory.java
@@ -9,12 +9,14 @@ import com.tenten.linkhub.global.util.SearchKeywordParser;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import static com.querydsl.core.types.dsl.Expressions.numberTemplate;
 import static com.tenten.linkhub.domain.space.model.space.QSpace.space;
 
 @NoArgsConstructor
+@Component
 public class DynamicQueryFactory {
 
     public OrderSpecifier<String> spaceSort(Pageable pageable) {

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/querydsl/SpaceQueryDslRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/querydsl/SpaceQueryDslRepository.java
@@ -120,7 +120,7 @@ public class SpaceQueryDslRepository {
                         dynamicQueryFactory.eqSpaceName(condition.keyWord()),
                         dynamicQueryFactory.eqCategory(condition.filter())
                 )
-                .orderBy(space.createdAt.desc())
+                .orderBy(space.id.desc())
                 .offset(condition.pageable().getOffset())
                 .limit(condition.pageable().getPageSize() + 1)
                 .fetch();

--- a/src/main/java/com/tenten/linkhub/domain/space/repository/space/querydsl/SpaceQueryDslRepository.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/repository/space/querydsl/SpaceQueryDslRepository.java
@@ -5,9 +5,10 @@ import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.repository.common.dto.QSpaceAndOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndOwnerNickName;
 import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
-import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickNames;
 import com.tenten.linkhub.domain.space.repository.space.dto.MemberSpacesQueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.dto.QueryCondition;
+import com.tenten.linkhub.domain.space.repository.common.mapper.RepositoryDtoMapper;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
@@ -19,16 +20,13 @@ import static com.tenten.linkhub.domain.space.model.space.QSpace.space;
 import static com.tenten.linkhub.domain.space.model.space.QSpaceImage.spaceImage;
 import static com.tenten.linkhub.domain.space.model.space.QSpaceMember.spaceMember;
 
+@RequiredArgsConstructor
 @Repository
 public class SpaceQueryDslRepository {
 
     private final JPAQueryFactory queryFactory;
     private final DynamicQueryFactory dynamicQueryFactory;
-
-    public SpaceQueryDslRepository(JPAQueryFactory queryFactory) {
-        this.queryFactory = queryFactory;
-        this.dynamicQueryFactory = new DynamicQueryFactory();
-    }
+    private final RepositoryDtoMapper mapper;
 
     public Slice<SpaceAndSpaceImageOwnerNickName> findPublicSpacesJoinSpaceImageByCondition(QueryCondition condition) {
         List<SpaceAndOwnerNickName> spaceAndOwnerNickNames = queryFactory
@@ -49,12 +47,9 @@ public class SpaceQueryDslRepository {
                 .fetch();
 
         List<Long> spaceIds = getSpaceIds(spaceAndOwnerNickNames);
-
         List<SpaceImage> spaceImages = findSpaceImagesBySpaceIds(spaceIds);
 
-        SpaceAndSpaceImageOwnerNickNames spaceAndSpaceImageOwnerNickNames = SpaceAndSpaceImageOwnerNickNames.of(spaceAndOwnerNickNames, spaceImages);
-
-        List<SpaceAndSpaceImageOwnerNickName> contents = spaceAndSpaceImageOwnerNickNames.contents();
+        List<SpaceAndSpaceImageOwnerNickName> contents = mapper.toSpaceAndSpaceImageOwnerNickNames(spaceAndOwnerNickNames, spaceImages);
         boolean hasNext = false;
 
         if (contents.size() > condition.pageable().getPageSize()) {
@@ -86,12 +81,9 @@ public class SpaceQueryDslRepository {
                 .fetch();
 
         List<Long> spaceIds = getSpaceIds(spaceAndOwnerNickNames);
-
         List<SpaceImage> spaceImages = findSpaceImagesBySpaceIds(spaceIds);
 
-        SpaceAndSpaceImageOwnerNickNames spaceAndSpaceImageOwnerNickNames = SpaceAndSpaceImageOwnerNickNames.of(spaceAndOwnerNickNames, spaceImages);
-
-        List<SpaceAndSpaceImageOwnerNickName> contents = spaceAndSpaceImageOwnerNickNames.contents();
+        List<SpaceAndSpaceImageOwnerNickName> contents = mapper.toSpaceAndSpaceImageOwnerNickNames(spaceAndOwnerNickNames, spaceImages);;
         boolean hasNext = false;
 
         if (contents.size() > condition.pageable().getPageSize()) {

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
@@ -1,5 +1,6 @@
 package com.tenten.linkhub.domain.space.service;
 
+import com.tenten.linkhub.domain.space.common.SpaceCursorSlice;
 import com.tenten.linkhub.domain.space.model.space.Scrap;
 import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.model.space.SpaceImage;
@@ -14,12 +15,14 @@ import com.tenten.linkhub.domain.space.service.dto.space.DeletedSpaceImageNames;
 import com.tenten.linkhub.domain.space.service.dto.space.MemberSpacesFindRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.NewSpacesScrapRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindWithFilterRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagGetResponse;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagGetResponses;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceUpdateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceWithSpaceImageAndSpaceMemberInfo;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryResponses;
+import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindWithCursorResponses;
 import com.tenten.linkhub.domain.space.service.dto.spacemember.SpaceMemberRoleChangeRequest;
 import com.tenten.linkhub.domain.space.service.mapper.SpaceMapper;
 
@@ -61,18 +64,17 @@ public class DefaultSpaceService implements SpaceService {
 
     @Override
     @Transactional(readOnly = true)
-    public SpacesFindByQueryResponses findPublicSpacesByQuery(PublicSpacesFindByQueryRequest request) {
-        validateSearchKeWord(request.keyWord());
-        Slice<SpaceAndSpaceImageOwnerNickName> spaceAndSpaceImageOwnerNickName = spaceRepository.findPublicSpacesJoinSpaceImageByQuery(mapper.toQueryCond(request));
+    public SpacesFindWithCursorResponses findPublicSpacesWithFilter(PublicSpacesFindWithFilterRequest request) {
+        SpaceCursorSlice<SpaceAndSpaceImageOwnerNickName> spaceAndSpaceImageOwnerNickName = spaceRepository.findPublicSpacesJoinSpaceImageByQuery(mapper.toCursorPageQueryCondition(request));
 
-        return SpacesFindByQueryResponses.from(spaceAndSpaceImageOwnerNickName);
+        return SpacesFindWithCursorResponses.from(spaceAndSpaceImageOwnerNickName);
     }
 
     @Override
     @Transactional(readOnly = true)
     public SpacesFindByQueryResponses searchPublicSpacesByQuery(PublicSpacesFindByQueryRequest request) {
         validateSearchKeWord(request.keyWord());
-        Slice<SpaceAndSpaceImageOwnerNickName> spaceAndSpaceImageOwnerNickName = spaceRepository.findPublicSpacesJoinSpaceImageByQuery(mapper.toQueryCond(request));
+        Slice<SpaceAndSpaceImageOwnerNickName> spaceAndSpaceImageOwnerNickName = spaceRepository.searchPublicSpacesJoinSpaceImageByQuery(mapper.toQueryCond(request));
 
         return SpacesFindByQueryResponses.from(spaceAndSpaceImageOwnerNickName);
     }

--- a/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/DefaultSpaceService.java
@@ -69,6 +69,15 @@ public class DefaultSpaceService implements SpaceService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public SpacesFindByQueryResponses searchPublicSpacesByQuery(PublicSpacesFindByQueryRequest request) {
+        validateSearchKeWord(request.keyWord());
+        Slice<SpaceAndSpaceImageOwnerNickName> spaceAndSpaceImageOwnerNickName = spaceRepository.findPublicSpacesJoinSpaceImageByQuery(mapper.toQueryCond(request));
+
+        return SpacesFindByQueryResponses.from(spaceAndSpaceImageOwnerNickName);
+    }
+
+    @Override
     @Transactional
     public Long createSpace(SpaceCreateRequest request) {
         SpaceMember spaceMember = mapper.toSpaceMember(request.memberId(), OWNER);

--- a/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
@@ -15,6 +15,8 @@ public interface SpaceService {
 
     SpacesFindByQueryResponses findPublicSpacesByQuery(PublicSpacesFindByQueryRequest request);
 
+    SpacesFindByQueryResponses searchPublicSpacesByQuery(PublicSpacesFindByQueryRequest request);
+
     Long createSpace(SpaceCreateRequest spaceCreateRequest);
 
     SpaceWithSpaceImageAndSpaceMemberInfo getSpaceWithSpaceImageAndSpaceMemberById(Long spaceId, Long memberId);

--- a/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/SpaceService.java
@@ -4,16 +4,18 @@ import com.tenten.linkhub.domain.space.service.dto.space.DeletedSpaceImageNames;
 import com.tenten.linkhub.domain.space.service.dto.space.MemberSpacesFindRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.NewSpacesScrapRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindWithFilterRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindByQueryResponses;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceTagGetResponses;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceUpdateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceWithSpaceImageAndSpaceMemberInfo;
+import com.tenten.linkhub.domain.space.service.dto.space.SpacesFindWithCursorResponses;
 import com.tenten.linkhub.domain.space.service.dto.spacemember.SpaceMemberRoleChangeRequest;
 
 public interface SpaceService {
 
-    SpacesFindByQueryResponses findPublicSpacesByQuery(PublicSpacesFindByQueryRequest request);
+    SpacesFindWithCursorResponses findPublicSpacesWithFilter(PublicSpacesFindWithFilterRequest request);
 
     SpacesFindByQueryResponses searchPublicSpacesByQuery(PublicSpacesFindByQueryRequest request);
 

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/space/PublicSpacesFindWithFilterRequest.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/space/PublicSpacesFindWithFilterRequest.java
@@ -1,0 +1,10 @@
+package com.tenten.linkhub.domain.space.service.dto.space;
+
+import com.tenten.linkhub.domain.space.common.SpaceCursorPageRequest;
+
+public record PublicSpacesFindWithFilterRequest(
+        SpaceCursorPageRequest pageable,
+        Long lastFavoriteCount,
+        Long lastSpaceId
+) {
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/service/dto/space/SpacesFindWithCursorResponses.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/dto/space/SpacesFindWithCursorResponses.java
@@ -1,0 +1,30 @@
+package com.tenten.linkhub.domain.space.service.dto.space;
+
+import com.tenten.linkhub.domain.space.common.SpaceCursorSlice;
+import com.tenten.linkhub.domain.space.repository.common.dto.SpaceAndSpaceImageOwnerNickName;
+
+import java.util.Objects;
+
+public record SpacesFindWithCursorResponses(SpaceCursorSlice<SpacesFindByQueryResponse> responses) {
+
+    public static SpacesFindWithCursorResponses from(SpaceCursorSlice<SpaceAndSpaceImageOwnerNickName> response){
+        SpaceCursorSlice<SpacesFindByQueryResponse> mapResponses = response.map(s -> new SpacesFindByQueryResponse(
+                s.space().getId(),
+                s.space().getSpaceName(),
+                Objects.isNull(s.space().getDescription()) ? "" : s.space().getDescription(),
+                s.space().getCategory(),
+                s.space().getIsVisible(),
+                s.space().getIsComment(),
+                s.space().getIsLinkSummarizable(),
+                s.space().getIsReadMarkEnabled(),
+                s.space().getViewCount(),
+                s.space().getScrapCount(),
+                s.space().getFavoriteCount(),
+                s.spaceImages().isEmpty() ? null : s.spaceImages().get(0).getPath(),
+                s.ownerNickName()
+        ));
+
+        return new SpacesFindWithCursorResponses(mapResponses);
+    }
+
+}

--- a/src/main/java/com/tenten/linkhub/domain/space/service/mapper/SpaceMapper.java
+++ b/src/main/java/com/tenten/linkhub/domain/space/service/mapper/SpaceMapper.java
@@ -5,10 +5,12 @@ import com.tenten.linkhub.domain.space.model.space.Space;
 import com.tenten.linkhub.domain.space.model.space.SpaceImage;
 import com.tenten.linkhub.domain.space.model.space.SpaceMember;
 import com.tenten.linkhub.domain.space.model.space.dto.SpaceUpdateDto;
+import com.tenten.linkhub.domain.space.repository.space.dto.CursorPageQueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.dto.MemberSpacesQueryCondition;
 import com.tenten.linkhub.domain.space.repository.space.dto.QueryCondition;
 import com.tenten.linkhub.domain.space.service.dto.space.MemberSpacesFindRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.NewSpacesScrapRequest;
+import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindWithFilterRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceCreateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.SpaceUpdateRequest;
 import com.tenten.linkhub.domain.space.service.dto.space.PublicSpacesFindByQueryRequest;
@@ -25,6 +27,14 @@ public class SpaceMapper {
                 request.pageable(),
                 request.keyWord(),
                 request.filter());
+    }
+
+    public CursorPageQueryCondition toCursorPageQueryCondition(PublicSpacesFindWithFilterRequest request) {
+        return new CursorPageQueryCondition(
+                request.pageable(),
+                request.lastFavoriteCount(),
+                request.lastSpaceId()
+        );
     }
 
     public Space toSpace(SpaceCreateRequest request, SpaceMember spaceMember, SpaceImage spaceImage) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
       url: ${LOKI_URL}
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/link_hub_query_test?serverTimezone=Asia/Seoul&rewriteBatchedStatements=true
+    url: ${RDS_URL}
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
   servlet:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
       url: ${LOKI_URL}
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${RDS_URL}
+    url: jdbc:mysql://localhost:3306/link_hub_query_test?serverTimezone=Asia/Seoul&rewriteBatchedStatements=true
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
   servlet:

--- a/src/main/resources/db/migration/V3__update_index_to_space_table.sql
+++ b/src/main/resources/db/migration/V3__update_index_to_space_table.sql
@@ -1,0 +1,4 @@
+DROP INDEX idx_spaces_created_at ON spaces;
+DROP INDEX idx_spaces_favorite_count ON spaces;
+
+CREATE INDEX idx_spaces_favorite_count_id ON spaces (favorite_count desc, id desc);


### PR DESCRIPTION
## 작업한 일
- 스페이스 필터 조회와 스페이스 검색 의 service 및 repository 레이어의 메서드를 분리하였습니다.
  - 메서드 분리에 따라 테스트 코드를 변경하였습니다.
- 메인페이지용 스페이스 필터 조회 API를 no offset 방식 중 하나인 cursor-based pagination 방식으로 변경하였습니다.